### PR TITLE
fix(github-actions): fix CVE-2025-30066 and pre-emptive security measures

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     outputs:
@@ -33,7 +36,7 @@ jobs:
 
     - name: Determine what files types have changed
       id: changed-files-yaml
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           actions:

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   load-image-metadata:
     uses: ./.github/workflows/load-metadata.yaml

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   load-image-metadata:
     uses: ./.github/workflows/load-metadata.yaml

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   load-image-metadata:
     uses: ./.github/workflows/load-metadata.yaml

--- a/.github/workflows/update-aqua-checksum.yaml
+++ b/.github/workflows/update-aqua-checksum.yaml
@@ -12,11 +12,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update-aqua-checksums:
     uses: aquaproj/update-checksum-workflow/.github/workflows/update-checksum.yaml@8bce60cc4475128360bc32f00707abb874ca4a91 # v1.0.3
-    permissions:
-      contents: read
     with:
       # renovate: datasource=github-releases depName=aquaproj/aqua
       aqua_version: v2.45.1


### PR DESCRIPTION
- Fix CVE-2025-30066 by upgrading to tj-actions/changed-files to v46
- Rotate all secrets used in Github Actions
- Setup pre-emptive measures to limit the blast radius of future vulnerabilities in github actions
  - explicitly set permission for default GITHUB_TOKEN to limit its capabilities to whats needed
