### PR TITLE
docs: add CLAUDE.md and DESIGN.md, cross-reference with README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+A monorepo of independently-versioned, independently-released Docker images published to Docker
+Hub as `ppatlabs/<image>` — currently `bitwarden-cli`, `freeradius-server`, and `tools` (see
+[README.md](README.md) for the catalog). There is no shared application code or package manager;
+each top-level directory is a self-contained image: `Dockerfile`, `metadata.yaml`, `README.md`,
+plus whatever else that image needs (e.g. `entrypoint.sh`, `aqua.yaml`).
+
+For the reasoning behind the CI/release structure and per-image trade-offs, see
+[DESIGN.md](DESIGN.md). Most of this repo's commit history is Renovate-authored dependency bumps,
+not hand-written changes — expect a typical task here to be a version bump, a small Dockerfile
+edit, or adding a new image, not application feature work.
+
+## Commands
+
+### Build an image locally
+
+```
+docker build -t <image>:test ./<image>
+```
+
+Multi-arch build matching CI (requires buildx + binfmt for the non-native arch):
+
+```
+docker buildx build --platform linux/amd64,linux/arm64 ./<image>
+```
+
+### Lint
+
+```
+pre-commit run --all-files
+```
+
+Run one hook against specific files:
+
+```
+pre-commit run hadolint --files tools/Dockerfile
+pre-commit run yamllint --files freeradius-server/metadata.yaml
+```
+
+Hooks (`.pre-commit-config.yaml`): standard pre-commit-hooks (large files, shebangs, private
+keys, EOF/CRLF), `yamllint --strict`, `markdownlint-cli2 --fix`, `shellcheck`, and `hadolint`
+(`--failure-threshold=warning`; DL3008/DL3018/DL4001/SC2155 are ignored repo-wide per
+`.hadolint.yaml` — don't flag these). `commitlint` also runs as a hook but only at the
+`commit-msg` stage, so it won't fire under `--all-files`.
+
+### How a change is verified
+
+There is no unit/integration test suite. Confidence comes from static analysis (the hooks above,
+plus CI's `lint.yaml`, which mirrors them and adds a GitHub Actions linter) followed by an actual
+build: on a PR touching `<image>/**`, `test-build-<image>.yaml` runs a real multi-arch
+(`linux/amd64,linux/arm64`) `docker buildx build` via the shared `build-docker-image.yaml`
+workflow (from the external `ppat/github-workflows` repo) — without pushing anywhere. A
+successful build on both architectures **is** the test. There's no local equivalent of the
+private-registry-cached CI build; the `docker buildx build` command above is the closest local
+approximation. See [DESIGN.md](DESIGN.md#decisions-and-trade-offs) for why this repo relies on
+build-as-test instead of a test suite.
+
+### Commit messages
+
+Conventional Commits, enforced by commitlint (`commitlint.config.js`) via both the `commit-msg`
+pre-commit hook and CI (`lint.yaml` → commit-messages job). Header ≤ 120 chars. `scope` must be
+one of the fixed values in `commitlint.config.js`'s `scope-enum`: empty, `aqua`, `bitwarden-cli`,
+`build`, `dev-tools`, `freeradius-server`, `github-actions`, `release`, `renovate`, `tools`.
+
+## Adding a new image
+
+Follow the existing per-image pattern (any of `bitwarden-cli`/`freeradius-server`/`tools` is a
+reference):
+
+1. Create `<name>/Dockerfile`, `<name>/metadata.yaml` (`image_version`, `label_title`,
+   `label_description`, `build_timeout` — read by `load-metadata.yaml`), `<name>/README.md`.
+2. Copy an existing image's `.github/workflows/test-build-<image>.yaml` and
+   `publish-<image>.yaml` pair, changing only the image name / context path. (These aren't a
+   single parameterized matrix workflow because GitHub Actions `paths:` trigger filters must be
+   static per file — see [DESIGN.md](DESIGN.md#decisions-and-trade-offs).)
+3. Add `<name>` to the `scope-enum` in `commitlint.config.js`.
+4. Add a row to the table in root [README.md](README.md).
+5. If the image pins versions via `# renovate: datasource=... depName=...` comments, confirm
+   Renovate's custom regex manager (`.github/renovate.json`) picks them up; add an
+   image-specific rule set under `.github/renovate/` only if it needs non-default
+   automerge/grouping behavior (see `image-updates-bitwarden-cli.json` /
+   `image-updates-freeradius-server.json` for the pattern).
+
+## Conventions specific to this repo
+
+- Base images are pinned by digest (e.g. `debian:bookworm-slim@sha256:...`,
+  `alpine:3.24.1@sha256:...`); builder stages use `--platform=$BUILDPLATFORM` and final stages
+  use `$TARGETPLATFORM` to keep cross-compilation correct.
+- A version pin only gets Renovate-managed if it carries a
+  `# renovate: datasource=... depName=...` comment directly above the `ARG`/YAML key —
+  omitting it silently opts that pin out of automated updates.
+- `metadata.yaml` is the single source of truth for an image's version and labels; don't
+  hardcode these in workflow files.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,134 @@
+# Design
+
+Why this repo is shaped the way it is: the decisions, the trade-offs behind them, and how the
+pieces work together as one system. For the image catalog and usage, see [README.md](README.md).
+For commands and repo-specific working conventions, see [CLAUDE.md](CLAUDE.md).
+
+## Intent
+
+This repo exists to publish a small number of Docker images to Docker Hub (`ppatlabs/<image>`)
+that the author's homelab/Kubernetes cluster depends on, and to keep those images' base images,
+CLI tool versions, and GitHub Actions references current with as little manual effort as
+possible. The commit history bears this out: the overwhelming majority of commits are
+Renovate-authored version bumps, not hand-written feature work. Every structural decision below
+optimizes for that reality — a repo mostly maintained by a bot, occasionally touched by a human
+adding or reworking one image.
+
+## System view
+
+```mermaid
+flowchart TB
+    subgraph src["source (per image dir)"]
+        DF[Dockerfile]
+        MD[metadata.yaml]
+    end
+
+    RENOVATE["renovate.yaml\n(daily cron)"] -->|version-bump PRs| DF
+    RENOVATE -->|version-bump PRs| MD
+
+    subgraph pr["Pull Request"]
+        LINT["lint.yaml\npath-filtered: docker / actions / markdown\nyaml / shellcheck / renovate-config / commits"]
+        LOADMETA1["load-metadata.yaml"]
+        TESTBUILD["test-build-&lt;image&gt;.yaml\n(triggers only on &lt;image&gt;/** changes)"]
+        BUILD1["ppat/github-workflows:\nbuild-docker-image.yaml"]
+    end
+
+    subgraph mainpush["push to main"]
+        LOADMETA2["load-metadata.yaml"]
+        RELEASE["release-workflow.yaml:\ntag + changelog from git log,\nscoped to this image's folder\nsince its last release"]
+        BUILD2["ppat/github-workflows:\nbuild-docker-image.yaml"]
+    end
+
+    DF --> TESTBUILD
+    MD --> LOADMETA1 --> TESTBUILD
+    TESTBUILD --> BUILD1 --> CACHE[("private registry\n(build cache only)")]
+
+    DF -->|merge| RELEASE
+    MD --> LOADMETA2 --> RELEASE
+    RELEASE --> GHREL["GitHub Release\n(skipped if no changes)"]
+    RELEASE --> BUILD2
+    BUILD2 --> DOCKERHUB[("Docker Hub\nppatlabs/&lt;image&gt;")]
+    BUILD2 --> PRIVREG[("private registry")]
+```
+
+The loop that actually drives most activity is Renovate → PR → `test-build` (lint + real
+multi-arch build, no push) → merge → `publish` (tag, changelog, build, push). A human only enters
+this loop to add a new image or change one image's Dockerfile/entrypoint by hand.
+
+## Decisions and trade-offs
+
+**One repo, one image per top-level directory, each released independently.**
+Images share nothing at runtime and have almost nothing in common (a `bitwarden-cli` release has
+no bearing on `freeradius-server`), so each gets its own version, its own GitHub Release tag
+(`<image>/<version>-<timestamp>`), and its own changelog scoped to `git log -- <image>/` since
+that image's last release. The monorepo container exists purely so the three images can share one
+CI/lint/Renovate configuration instead of maintaining it three times. The cost is workflow
+duplication: `publish-<image>.yaml` and `test-build-<image>.yaml` exist once per image and differ
+only in `image_name` and the registry paths derived from it, because GitHub Actions `paths:`
+trigger filters must be static per workflow file — they can't be computed from a matrix at trigger
+time, which is what would otherwise let one parameterized workflow cover all three images.
+
+**`metadata.yaml` as the single per-image source of truth.**
+`image_version`, `label_title`, `label_description`, and `build_timeout` live in one YAML file per
+image and are read at CI time by `load-metadata.yaml`, rather than being duplicated as workflow
+inputs or baked into each Dockerfile. This is what lets the publish/test-build workflows stay
+nearly identical across images — only the metadata content differs, not the workflow logic.
+
+**Release only happens if there's something to release.**
+`release-workflow.yaml` computes the changelog range from the last release tag matching
+`<image>/*` and aborts the release (non-zero exit, no tag, no build/push) if that range produces
+no commits touching the image's folder. Without this, merging a change to `tools/` would also
+mint an empty, meaningless release for `bitwarden-cli` and `freeradius-server` since all three
+publish workflows watch the same `main` branch.
+
+**PR builds build for real (multi-arch, to a private cache) but never push to Docker Hub.**
+The only pre-merge signal that an image is buildable is an actual `docker buildx build` across
+`linux/amd64,linux/arm64`, executed via the shared `build-docker-image.yaml` reusable workflow.
+There is no separate unit/integration test suite — for a Dockerfile-only repo, "it builds
+correctly for both target architectures" is the meaningful test. See
+[CLAUDE.md](CLAUDE.md#how-a-change-is-verified) for how to approximate this locally.
+
+**CI logic lives in a separate `ppat/github-workflows` repo, pinned by SHA with a version-tag
+comment.** Reusable steps (build-docker-image, the per-linter jobs, detect-changed-files,
+update-aqua-checksums, renovate) are shared not just across this repo's three images but across
+the author's other repos. The cost is an external dependency that this repo can't unilaterally
+change — mitigated by pinning to a commit SHA (not just a tag) so Renovate-driven bumps to it are
+auditable and reviewable like any other dependency update.
+
+**Renovate is tuned per risk tier, not applied uniformly.** `image-updates.json` and
+`aqua-cli-tools.json` both separate patch/minor/major and gate automerge behind a minimum release
+age (1/7/30+ days respectively), with major bumps always requiring manual merge and a
+`BREAKING CHANGE` marker. Given how much of this repo's traffic is Renovate PRs, uniform
+automerge would be too risky (silently shipping a major bump) and uniform manual review would
+defeat the point of automation — the tiering is the trade-off resolution.
+
+**`tools` is a multi-stage build using `aqua` as a declarative CLI version manager, with a
+builder stage that compresses binaries via `upx` before copying only the compiled binaries into
+the final Alpine stage.** This keeps the runtime image to "Alpine + apk packages + a handful of
+static binaries" rather than carrying aqua itself or Go/Rust toolchains into the shipped image;
+the trade-off is a more complex two-stage Dockerfile and reliance on `aqua`'s checksum file
+(`tools/aqua-checksums.json`, kept current by `update-aqua-checksum.yaml`) for supply-chain
+integrity.
+
+**`bitwarden-cli` and `freeradius-server` build on `debian:bookworm-slim`, not Alpine.**
+`bitwarden-cli` needs glibc-linked shared libraries the upstream CLI binary was built against;
+`freeradius-server` needs a wide set of optional protocol/driver libraries (LDAP, MySQL, Postgres,
+Redis, unixODBC, etc.) that are far easier to satisfy from Debian's package set. Both accept the
+larger base image size as the cost of avoiding a from-scratch musl/Alpine port.
+
+**`freeradius-server` builds FreeRADIUS from source against a pinned upstream git tag rather than
+re-tagging the official image.** The official `freeradius/freeradius-server` image doesn't cover
+`arm64`; building from `debian/rules`/`dpkg-buildpackage` in a builder stage, keyed by
+`$TARGETARCH`, is what makes the image genuinely multi-arch — the trade-off is a much longer,
+much slower (`build_timeout: 180`) build compared to the other two images.
+
+## Outcomes targeted
+
+- Every published image is reproducible from a pinned digest/version and carries build
+  provenance labels (`label_title`/`label_description` from `metadata.yaml`).
+- `linux/amd64` and `linux/arm64` support for every image, verified on every PR, not just at
+  release time.
+- Dependency currency (base images, CLI tool pins, Actions refs) with near-zero manual toil for
+  low-risk bumps, while major/breaking bumps still get a human in the loop.
+- A per-image, human-readable release history despite the shared monorepo — a `freeradius-server`
+  release note never mentions unrelated `tools` changes and vice versa.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
 # images
 
+Docker images published to Docker Hub as `ppatlabs/<image>`, each versioned and released
+independently of the others. See each image's own README for what it does and how to run it;
+see [DESIGN.md](DESIGN.md) for why the repo and its CI/release pipeline are structured this way,
+and [CLAUDE.md](CLAUDE.md) for build/lint commands.
+
 | image | build-status |
 | --- | --- |
 | [bitwarden-cli](./bitwarden-cli/) | [![test-build-bitwarden-cli](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml) |
 | [tools](./tools/) | [![test-tools](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml) |
 | [freeradius-server](./freeradius-server/) | [![test-build-freeradius-server](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml) |
+
+## Releases
+
+Each image gets its own GitHub Release, tagged `<image>/<version>-<timestamp>`, cut automatically
+on merge to `main` when that image's files changed — a release only happens if there are actual
+changes to release. See [DESIGN.md](DESIGN.md#decisions-and-trade-offs) for the full mechanics.
+
+## Contributing
+
+Commit messages follow Conventional Commits, checked by commitlint against a fixed scope list
+(see `commitlint.config.js`). For local build/lint commands and the pattern for adding a new
+image, see [CLAUDE.md](CLAUDE.md).
+
+## License
+
+[GNU AGPLv3](LICENSE)


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md`: agent-facing build/lint commands, how a change is actually verified in this repo (build-as-test, no unit test suite), and the steps for adding a new image.
- Adds `DESIGN.md`: the intent and trade-offs behind the per-image release/CI structure (independent releases in one monorepo, `metadata.yaml` as source of truth, why publish/test-build workflows are duplicated per image, tiered Renovate automerge, per-image base-image choices), with a Mermaid diagram of the full pipeline.
- Updates `README.md` to stay the human-facing catalog, cross-referencing the two new docs instead of duplicating their content.

## Test plan
- [x] `pre-commit run --all-files` passes (ran automatically on commit)
- [x] `npx markdownlint-cli2 --config .markdownlint-cli2.yaml README.md DESIGN.md CLAUDE.md` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)