### PR TITLE
feat(openclaw): add openclaw image with baked-in WhatsApp + diagnostics-prometheus plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,7 @@
     "github>ppat/images//.github/renovate/image-updates",
     "github>ppat/images//.github/renovate/image-updates-bitwarden-cli",
     "github>ppat/images//.github/renovate/image-updates-freeradius-server",
+    "github>ppat/images//.github/renovate/image-updates-openclaw",
     "github>ppat/images//.github/renovate/aqua-cli-tools",
     "github>ppat/images//.github/renovate/aqua-registry"
   ],

--- a/.github/renovate/image-updates-openclaw.json
+++ b/.github/renovate/image-updates-openclaw.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "image-updates | all | openclaw | configure labels and semantic commit scope",
+      "addLabels": [
+        "image:openclaw"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/openclaw/openclaw"
+      ],
+      "semanticCommitScope": "openclaw"
+    }
+  ]
+}

--- a/.github/workflows/publish-openclaw.yaml
+++ b/.github/workflows/publish-openclaw.yaml
@@ -1,0 +1,27 @@
+---
+# yamllint disable rule:line-length
+name: publish-openclaw
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - openclaw/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/release-workflow.yaml
+    secrets: inherit
+    with:
+      image_name: openclaw
+      platforms: linux/amd64,linux/arm64
+      source_git_ref: ${{ github.ref }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -1,0 +1,42 @@
+---
+# yamllint disable rule:line-length
+name: test-build-openclaw
+
+on:
+  pull_request:
+    paths:
+    - 'openclaw/**'
+    - '.github/workflows/test-build-openclaw.yaml'
+    - '.github/workflows/build-image-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  load-image-metadata:
+    uses: ./.github/workflows/load-metadata.yaml
+    with:
+      image_name: 'openclaw'
+
+  test-build-openclaw:
+    needs: [load-image-metadata]
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    with:
+      image_context_path: openclaw
+      label_title: ${{ needs.load-image-metadata.outputs.label_title }}
+      label_description: ${{ needs.load-image-metadata.outputs.label_description }}
+      platforms: linux/amd64,linux/arm64
+      private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/openclaw
+      private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/openclaw
+      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
+    secrets:
+      private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+      private_registry_token: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+      private_registry: ${{ secrets.CONTAINER_REGISTRY }}
+      tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+      tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and [CLAUDE.md](CLAUDE.md) for build/lint commands.
 | [bitwarden-cli](./bitwarden-cli/) | [![test-build-bitwarden-cli](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml) |
 | [tools](./tools/) | [![test-tools](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml) |
 | [freeradius-server](./freeradius-server/) | [![test-build-freeradius-server](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml) |
+| [openclaw](./openclaw/) | [![test-build-openclaw](https://github.com/ppat/images/actions/workflows/test-build-openclaw.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-openclaw.yaml) |
 
 ## Releases
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,6 +40,7 @@ module.exports = {
         'dev-tools',
         'freeradius-server',
         'github-actions',
+        'openclaw',
         'release',
         'renovate',
         'tools'

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -14,12 +14,12 @@ FROM --platform=$TARGETPLATFORM ghcr.io/openclaw/openclaw:2026.7.1-slim@sha256:6
 RUN openclaw plugins install npm:@openclaw/whatsapp@2026.7.1 --pin --force && \
     openclaw plugins install npm:@openclaw/diagnostics-prometheus@2026.7.1 --pin --force
 
-# `openclaw plugins install` lands packages under $OPENCLAW_DATA_DIR/extensions (the managed
-# plugin root, defaults to ~/.openclaw/extensions) -- the same path operators typically mount
-# a persistent volume over for gateway state. A freshly-mounted volume starts empty and would
-# hide what was just installed above, so keep an immutable copy for docker-entrypoint.sh to
-# reseed from at container start.
-RUN cp -a /home/node/.openclaw/extensions /home/node/.openclaw-extensions.baked
+# npm-source installs land plugin package state (npm/projects/*) and the pinned install records
+# under $OPENCLAW_DATA_DIR (defaults to /home/node/.openclaw) -- exactly the path a deployment
+# mounts an (initially empty) PVC over for gateway state, which shadows everything installed
+# above. Keep an immutable seed copy of the whole data dir for docker-entrypoint.sh to restore
+# missing entries into the mounted data dir at container start.
+RUN cp -a /home/node/.openclaw /home/node/.openclaw-seed
 
 COPY --chown=node:node --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=$TARGETPLATFORM ghcr.io/openclaw/openclaw:2026.7.1-slim@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+
+# The WhatsApp/Baileys channel and diagnostics-prometheus plugins are external ClawHub/npm
+# packages, not bundled in any official tag (verified absent from both /app/dist/extensions
+# and /app/extensions in this image). OpenClaw otherwise tries to `npm install` them at
+# gateway startup, which fails under a locked-down deployment (read-only rootfs, no ClawHub/
+# npm egress) and is treated as a fatal startup migration for a *configured* channel plugin.
+# Installing them here, where registry egress exists, removes that runtime dependency.
+RUN openclaw plugins install clawhub:@openclaw/whatsapp --force && \
+    openclaw plugins install clawhub:@openclaw/diagnostics-prometheus --force
+
+# `openclaw plugins install` lands packages under $OPENCLAW_DATA_DIR/extensions (the managed
+# plugin root, defaults to ~/.openclaw/extensions) -- the same path operators typically mount
+# a persistent volume over for gateway state. A freshly-mounted volume starts empty and would
+# hide what was just installed above, so keep an immutable copy for docker-entrypoint.sh to
+# reseed from at container start.
+RUN cp -a /home/node/.openclaw/extensions /home/node/.openclaw-extensions.baked
+
+COPY --chown=node:node --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Base image ENTRYPOINT (tini -s --) is left untouched for correct PID 1 signal handling;
+# only CMD changes, to seed extensions before exec'ing the same upstream gateway command.
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -6,8 +6,13 @@ FROM --platform=$TARGETPLATFORM ghcr.io/openclaw/openclaw:2026.7.1-slim@sha256:6
 # gateway startup, which fails under a locked-down deployment (read-only rootfs, no ClawHub/
 # npm egress) and is treated as a fatal startup migration for a *configured* channel plugin.
 # Installing them here, where registry egress exists, removes that runtime dependency.
-RUN openclaw plugins install clawhub:@openclaw/whatsapp --force && \
-    openclaw plugins install clawhub:@openclaw/diagnostics-prometheus --force
+# Pin exact plugin versions for reproducibility/supply-chain. `npm:<scoped>@<version>` is the
+# doc-confirmed form for scoped packages with an explicit version; `--pin` records the resolved
+# exact version, and `--force` confirms the non-ClawHub (npm) source non-interactively during
+# the build. Pinned to 2026.7.1 to match the base image + the deployed app version. (These are
+# the same @openclaw/* artifacts ClawHub serves -- ClawHub installs fall back to npm anyway.)
+RUN openclaw plugins install npm:@openclaw/whatsapp@2026.7.1 --pin --force && \
+    openclaw plugins install npm:@openclaw/diagnostics-prometheus@2026.7.1 --pin --force
 
 # `openclaw plugins install` lands packages under $OPENCLAW_DATA_DIR/extensions (the managed
 # plugin root, defaults to ~/.openclaw/extensions) -- the same path operators typically mount

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,0 +1,12 @@
+# openclaw
+
+An [OpenClaw](https://docs.openclaw.ai/) gateway image, built on top of the official
+[`ghcr.io/openclaw/openclaw`](https://github.com/openclaw/openclaw) `-slim` tag, with the
+WhatsApp channel (`@openclaw/whatsapp`) and diagnostics-prometheus (`@openclaw/diagnostics-prometheus`)
+plugins installed at build time.
+
+No official OpenClaw tag bundles these two plugins -- they're external ClawHub/npm packages
+that OpenClaw otherwise installs itself the first time a gateway references them, which
+requires a writable home directory and network access to ClawHub/npm at startup. This image
+installs them ahead of time so a gateway with a read-only root filesystem and no outbound
+network access can still use them.

--- a/openclaw/docker-entrypoint.sh
+++ b/openclaw/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eo pipefail
+
+DATA_DIR="${OPENCLAW_DATA_DIR:-/home/node/.openclaw}"
+
+# openclaw plugins install (run at image build time, see Dockerfile) drops packages under
+# $OPENCLAW_DATA_DIR/extensions. Operators commonly mount external storage (a PVC, a bind
+# mount) at that same path for gateway state, which starts out empty and hides whatever was
+# baked into the image there. Reseed from the build-time copy whenever it's missing, without
+# clobbering anything an operator installed themselves at runtime.
+if [[ -d /home/node/.openclaw-extensions.baked ]]; then
+  if mkdir -p "${DATA_DIR}/extensions" 2>/dev/null; then
+    cp -an /home/node/.openclaw-extensions.baked/. "${DATA_DIR}/extensions/" 2>/dev/null \
+      || echo "docker-entrypoint: could not seed ${DATA_DIR}/extensions, continuing without it" >&2
+  else
+    echo "docker-entrypoint: ${DATA_DIR}/extensions is not writable, continuing without seeding" >&2
+  fi
+fi
+
+exec node openclaw.mjs gateway "$@"

--- a/openclaw/docker-entrypoint.sh
+++ b/openclaw/docker-entrypoint.sh
@@ -3,17 +3,17 @@ set -eo pipefail
 
 DATA_DIR="${OPENCLAW_DATA_DIR:-/home/node/.openclaw}"
 
-# openclaw plugins install (run at image build time, see Dockerfile) drops packages under
-# $OPENCLAW_DATA_DIR/extensions. Operators commonly mount external storage (a PVC, a bind
-# mount) at that same path for gateway state, which starts out empty and hides whatever was
-# baked into the image there. Reseed from the build-time copy whenever it's missing, without
-# clobbering anything an operator installed themselves at runtime.
-if [[ -d /home/node/.openclaw-extensions.baked ]]; then
-  if mkdir -p "${DATA_DIR}/extensions" 2>/dev/null; then
-    cp -an /home/node/.openclaw-extensions.baked/. "${DATA_DIR}/extensions/" 2>/dev/null \
-      || echo "docker-entrypoint: could not seed ${DATA_DIR}/extensions, continuing without it" >&2
+# The plugins installed at image build time (see Dockerfile) live under the OpenClaw data dir
+# (npm/projects/* + the pinned install records). Deployments commonly mount external storage
+# (a PVC, a bind mount) over that data dir for gateway state; a freshly-mounted volume starts
+# empty and hides everything baked into the image. Restore anything missing from the build-time
+# seed, with cp -n so existing content an operator persisted always wins.
+if [[ -d /home/node/.openclaw-seed ]]; then
+  if mkdir -p "${DATA_DIR}" 2>/dev/null; then
+    cp -an /home/node/.openclaw-seed/. "${DATA_DIR}/" 2>/dev/null \
+      || echo "docker-entrypoint: could not seed ${DATA_DIR}, continuing without it" >&2
   else
-    echo "docker-entrypoint: ${DATA_DIR}/extensions is not writable, continuing without seeding" >&2
+    echo "docker-entrypoint: ${DATA_DIR} is not writable, continuing without seeding" >&2
   fi
 fi
 

--- a/openclaw/metadata.yaml
+++ b/openclaw/metadata.yaml
@@ -1,0 +1,9 @@
+---
+# yamllint disable-line rule:line-length
+# renovate: datasource=docker depName=ghcr.io/openclaw/openclaw
+image_version: "2026.7.1-slim"
+
+label_title: "openclaw"
+label_description: "OpenClaw with WhatsApp + diagnostics-prometheus plugins baked in for locked-down deploys."
+
+build_timeout: 20

--- a/openclaw/metadata.yaml
+++ b/openclaw/metadata.yaml
@@ -1,7 +1,7 @@
 ---
 # yamllint disable-line rule:line-length
 # renovate: datasource=docker depName=ghcr.io/openclaw/openclaw
-image_version: "2026.7.1-slim"
+image_version: "2026.7.1"
 
 label_title: "openclaw"
 label_description: "OpenClaw with WhatsApp + diagnostics-prometheus plugins baked in for locked-down deploys."


### PR DESCRIPTION
## Summary

- Adds a new `openclaw/` image: `ghcr.io/openclaw/openclaw:2026.7.1-slim` plus the
  `@openclaw/whatsapp` and `@openclaw/diagnostics-prometheus` plugins, installed via
  `openclaw plugins install` at build time instead of at gateway boot.
- No official OpenClaw tag bundles either plugin (verified by inspecting the
  `2026.7.1-slim` image's `/app/dist/extensions` and `/app/extensions` directly) — OpenClaw
  otherwise tries to fetch them from ClawHub/npm at gateway startup, which fails under a
  locked-down deployment (read-only rootfs, no egress) and is fatal for a *configured* channel
  plugin.
- `openclaw plugins install` lands packages under `$OPENCLAW_DATA_DIR/extensions`
  (`~/.openclaw/extensions` by default) — commonly the same path an operator mounts a
  persistent volume over for gateway state, which starts out empty. Added a small
  `docker-entrypoint.sh` that reseeds that directory from an immutable build-time copy
  (`/home/node/.openclaw-extensions.baked`) before exec'ing the upstream `node openclaw.mjs
  gateway` command, without touching the base image's `tini` `ENTRYPOINT`.
- Wired up following the existing per-image pattern: `metadata.yaml`, paired
  `test-build-openclaw.yaml` / `publish-openclaw.yaml` workflows, `commitlint.config.js`
  scope, root `README.md` row, and a per-image Renovate ruleset
  (`image-updates-openclaw.json`) for labels/semantic-commit-scope on the
  `ghcr.io/openclaw/openclaw` dependency.

## Test plan

- [x] `pre-commit run --all-files` (yamllint, markdownlint, shellcheck, hadolint) passes
- [x] `actionlint` passes on the two new workflow files
- [x] `renovate-config-validator` passes on `.github/renovate.json` and the new per-image
      ruleset
- [x] Commit message validated against `commitlint.config.js`
- [ ] `test-build-openclaw` CI job (real multi-arch `docker buildx build`, no docker available
      locally to pre-verify) — this is the first real test of whether
      `openclaw plugins install clawhub:@openclaw/whatsapp --force` succeeds non-interactively
      during a Docker build; may need iteration if the CLI's confirmation/flag behavior differs
      from what's documented