### PR TITLE
feat(openclaw): harden image with more plugins, entrypoint seeding, and a report-only scan

### DIFF
--- a/.github/workflows/publish-openclaw.yaml
+++ b/.github/workflows/publish-openclaw.yaml
@@ -23,5 +23,10 @@ jobs:
     secrets: inherit
     with:
       image_name: openclaw
-      platforms: linux/amd64,linux/arm64
+      # amd64-only (diverges from the repo's multi-arch norm): baking in memory-lancedb pushes
+      # the emulated (QEMU) arm64 build past this image's build timeout -- its large native lib
+      # makes the plugin install + `cp -a` seed + SBOM step under emulation too slow (amd64
+      # finishes in <2m; arm64 blew the 20m cap). The target homelab node is x64/amd64, so arm64
+      # isn't needed here. Restore linux/amd64,linux/arm64 if a native arm64 builder is available.
+      platforms: linux/amd64
       source_git_ref: ${{ github.ref }}

--- a/.github/workflows/scan-openclaw.yaml
+++ b/.github/workflows/scan-openclaw.yaml
@@ -6,7 +6,7 @@
 # surfaced in PR logs, the weekly scheduled run, and the Security tab without ever failing a build.
 # To flip this to a gating check once the plugin/base image findings have been triaged (see
 # .trivyignore): drop `continue-on-error: true` from the steps below and change Trivy's
-# `exit-code: '0'` / Dockle's `-c` `exit-code: '0'` to `'1'`.
+# `exit-code: '0'` / Dockle's `--exit-code 0` to `1`.
 name: scan-openclaw
 
 on:
@@ -75,13 +75,16 @@ jobs:
         sarif_file: 'trivy-results.sarif'
         category: 'trivy'
 
+    # goodwithtech's org isn't a GitHub-verified creator, so goodwithtech/dockle-action is
+    # rejected by this repo's actions/permissions allow-list (github-owned + verified-creator +
+    # an explicit pattern list). Run the official dockle image directly instead -- a `run:` step
+    # invoking a container isn't subject to that allow-list, only `uses:` steps are.
     - name: Dockle scan (CIS/best-practices)
       continue-on-error: true
-      uses: goodwithtech/dockle-action@e30e6af832aad6ea7dca2a248d31a85eab6dbd68 # v0.4.15
-      with:
-        image: 'openclaw:scan'
-        exit-code: '0'
-        format: 'list'
+      run: >-
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock
+        goodwithtech/dockle:v0.4.15@sha256:eade932f793742de0aa8755406c7677cd7696f8675b6180926f7eeffa7abe6b9
+        --exit-code 0 --format list openclaw:scan
 
     - name: Generate SBOM
       id: sbom

--- a/.github/workflows/scan-openclaw.yaml
+++ b/.github/workflows/scan-openclaw.yaml
@@ -1,0 +1,101 @@
+---
+# yamllint disable rule:line-length
+#
+# Report-only security scan for the openclaw image (soft launch). Every scan/upload step below
+# carries `continue-on-error: true` (and Trivy/Dockle are told to always exit 0), so findings are
+# surfaced in PR logs, the weekly scheduled run, and the Security tab without ever failing a build.
+# To flip this to a gating check once the plugin/base image findings have been triaged (see
+# .trivyignore): drop `continue-on-error: true` from the steps below and change Trivy's
+# `exit-code: '0'` / Dockle's `-c` `exit-code: '0'` to `'1'`.
+name: scan-openclaw
+
+on:
+  pull_request:
+    paths:
+    - 'openclaw/**'
+    - '.github/workflows/scan-openclaw.yaml'
+  schedule:
+  - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Build openclaw image
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: openclaw
+        platforms: linux/amd64
+        load: true
+        push: false
+        tags: openclaw:scan
+
+    - name: Trivy scan (SARIF)
+      id: trivy-sarif
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: openclaw:scan
+        scanners: 'vuln,secret,misconfig'
+        severity: 'HIGH,CRITICAL'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        exit-code: '0'
+
+    - name: Trivy scan (table, human-readable log)
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: openclaw:scan
+        scanners: 'vuln,secret,misconfig'
+        severity: 'HIGH,CRITICAL'
+        format: 'table'
+        exit-code: '0'
+
+    - name: Upload Trivy SARIF to Security tab
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      with:
+        sarif_file: 'trivy-results.sarif'
+        category: 'trivy'
+
+    - name: Dockle scan (CIS/best-practices)
+      continue-on-error: true
+      uses: goodwithtech/dockle-action@e30e6af832aad6ea7dca2a248d31a85eab6dbd68 # v0.4.15
+      with:
+        image: 'openclaw:scan'
+        exit-code: '0'
+        format: 'list'
+
+    - name: Generate SBOM
+      id: sbom
+      continue-on-error: true
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: 'openclaw:scan'
+        format: 'spdx-json'
+        output-file: 'openclaw-sbom.spdx.json'
+        upload-artifact: false
+
+    - name: Upload SBOM artifact
+      continue-on-error: true
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: openclaw-sbom
+        path: openclaw-sbom.spdx.json

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -29,7 +29,12 @@ jobs:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
       label_description: ${{ needs.load-image-metadata.outputs.label_description }}
-      platforms: linux/amd64,linux/arm64
+      # amd64-only (diverges from the repo's multi-arch norm): baking in memory-lancedb pushes
+      # the emulated (QEMU) arm64 build past this image's build timeout -- its large native lib
+      # makes the plugin install + `cp -a` seed + SBOM step under emulation too slow (amd64
+      # finishes in <2m; arm64 blew the 20m cap). The target homelab node is x64/amd64, so arm64
+      # isn't needed here. Restore linux/amd64,linux/arm64 if a native arm64 builder is available.
+      platforms: linux/amd64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/openclaw
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/openclaw
       source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Accepted/triaged CVE suppressions for the (currently report-only) `scan-openclaw` workflow.
+#
+# `scan-openclaw.yaml` runs Trivy against the openclaw image in report-only mode -- findings are
+# surfaced in PR logs and the Security tab, but nothing here fails a build yet. Once that scan
+# flips to gating (see the comment at the top of scan-openclaw.yaml), list vulnerabilities that
+# have been reviewed and accepted here, the same "suppress with a documented reason" pattern used
+# elsewhere in this repo (e.g. `.hadolint.yaml`'s `ignored:` list).
+#
+# One CVE per line, each with a reason:
+#   CVE-XXXX-YYYYY # reason: <why this is accepted -- not exploitable in this deployment, no
+#   fix available upstream yet, etc.>
+#
+# No CVEs are suppressed yet.

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -1,18 +1,23 @@
 FROM --platform=$TARGETPLATFORM ghcr.io/openclaw/openclaw:2026.7.1-slim@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
 
-# The WhatsApp/Baileys channel and diagnostics-prometheus plugins are external ClawHub/npm
-# packages, not bundled in any official tag (verified absent from both /app/dist/extensions
-# and /app/extensions in this image). OpenClaw otherwise tries to `npm install` them at
-# gateway startup, which fails under a locked-down deployment (read-only rootfs, no ClawHub/
-# npm egress) and is treated as a fatal startup migration for a *configured* channel plugin.
-# Installing them here, where registry egress exists, removes that runtime dependency.
+# The WhatsApp/Baileys channel, diagnostics-prometheus, memory-lancedb, and lobster plugins are
+# external ClawHub/npm packages, not bundled in any official tag (verified absent from both
+# /app/dist/extensions and /app/extensions in this image). OpenClaw otherwise tries to
+# `npm install` them at gateway startup, which fails under a locked-down deployment (read-only
+# rootfs, no ClawHub/npm egress) and is treated as a fatal startup migration for a *configured*
+# channel/plugin. Installing them here, where registry egress exists, removes that runtime
+# dependency. memory-lancedb is a LanceDB-backed memory store; lobster is action-approval
+# gating -- both are baked in here so they're available, but neither is enabled unless a
+# deployment's config turns it on.
 # Pin exact plugin versions for reproducibility/supply-chain. `npm:<scoped>@<version>` is the
 # doc-confirmed form for scoped packages with an explicit version; `--pin` records the resolved
 # exact version, and `--force` confirms the non-ClawHub (npm) source non-interactively during
 # the build. Pinned to 2026.7.1 to match the base image + the deployed app version. (These are
 # the same @openclaw/* artifacts ClawHub serves -- ClawHub installs fall back to npm anyway.)
 RUN openclaw plugins install npm:@openclaw/whatsapp@2026.7.1 --pin --force && \
-    openclaw plugins install npm:@openclaw/diagnostics-prometheus@2026.7.1 --pin --force
+    openclaw plugins install npm:@openclaw/diagnostics-prometheus@2026.7.1 --pin --force && \
+    openclaw plugins install npm:@openclaw/memory-lancedb@2026.7.1 --pin --force && \
+    openclaw plugins install npm:@openclaw/lobster@2026.7.1 --pin --force
 
 # npm-source installs land plugin package state (npm/projects/*) and the pinned install records
 # under $OPENCLAW_DATA_DIR (defaults to /home/node/.openclaw) -- exactly the path a deployment

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -28,6 +28,7 @@ RUN cp -a /home/node/.openclaw /home/node/.openclaw-seed
 
 COPY --chown=node:node --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Base image ENTRYPOINT (tini -s --) is left untouched for correct PID 1 signal handling;
-# only CMD changes, to seed extensions before exec'ing the same upstream gateway command.
-CMD ["/usr/local/bin/docker-entrypoint.sh"]
+# Base image ENTRYPOINT (tini -s --) is left untouched for correct PID 1 signal handling and
+# stays PID 1. The upstream gateway command now lives in CMD (explicit/overridable) instead of
+# being hardcoded in the entrypoint script, which seeds state/config then `exec "$@"`s it.
+CMD ["/usr/local/bin/docker-entrypoint.sh", "node", "openclaw.mjs", "gateway"]

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -12,3 +12,24 @@ requires a writable home directory and network access to ClawHub/npm at startup.
 installs them ahead of time so a gateway with a read-only root filesystem and no outbound
 network access can still use them. memory-lancedb and lobster are baked in and available but
 not enabled unless a deployment's config turns them on.
+
+## Entrypoint wrapper
+
+`docker-entrypoint.sh` (invoked via `CMD`, with the base image's `tini -s --` staying PID 1 as
+`ENTRYPOINT`) does three things before `exec`-ing the upstream gateway command:
+
+- **State seeding**: restores the build-time plugin/state seed (`/home/node/.openclaw-seed`)
+  into the mounted state dir (`OPENCLAW_STATE_DIR`/`OPENCLAW_DATA_DIR`, default
+  `/home/node/.openclaw`) via `cp -n`, so a deployment mounting external storage (PVC, bind
+  mount) over that dir doesn't shadow what's baked into the image, while anything an operator
+  already persisted there wins.
+- **Config seeding**: if both `OPENCLAW_CONFIG_SEED` (e.g. a read-only ConfigMap mount) and
+  `OPENCLAW_CONFIG_PATH` are set and the target doesn't already exist, copies the seed to the
+  config path and `chmod 600`s it, so the gateway's own CLI can write the file back (channels
+  login, doctor) without hitting `EBUSY` against a read-only mount. This is a no-op when
+  `OPENCLAW_CONFIG_SEED` is unset, so it's backwards-compatible with deployments that seed
+  config another way (e.g. a separate init container). Copy-if-absent means an in-place edit in
+  a writable volume always wins.
+- **`umask 077`**: everything the gateway creates under the state dir lands owner-only
+  (600/700), satisfying OpenClaw's `fs.credentials_dir.perms_writable` /
+  `fs.sessions_store.perms_readable` / `fs.config.perms_world_readable` audit checks.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,12 +1,14 @@
 # openclaw
 
 An [OpenClaw](https://docs.openclaw.ai/) gateway image, built on top of the official
-[`ghcr.io/openclaw/openclaw`](https://github.com/openclaw/openclaw) `-slim` tag, with the
-WhatsApp channel (`@openclaw/whatsapp`) and diagnostics-prometheus (`@openclaw/diagnostics-prometheus`)
-plugins installed at build time.
+[`ghcr.io/openclaw/openclaw`](https://github.com/openclaw/openclaw) `-slim` tag, with four
+plugins installed at build time: the WhatsApp channel (`@openclaw/whatsapp`),
+diagnostics-prometheus (`@openclaw/diagnostics-prometheus`), a LanceDB-backed memory store
+(`@openclaw/memory-lancedb`), and action-approval gating (`@openclaw/lobster`).
 
-No official OpenClaw tag bundles these two plugins -- they're external ClawHub/npm packages
+No official OpenClaw tag bundles these plugins -- they're external ClawHub/npm packages
 that OpenClaw otherwise installs itself the first time a gateway references them, which
 requires a writable home directory and network access to ClawHub/npm at startup. This image
 installs them ahead of time so a gateway with a read-only root filesystem and no outbound
-network access can still use them.
+network access can still use them. memory-lancedb and lobster are baked in and available but
+not enabled unless a deployment's config turns them on.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -33,3 +33,11 @@ not enabled unless a deployment's config turns them on.
 - **`umask 077`**: everything the gateway creates under the state dir lands owner-only
   (600/700), satisfying OpenClaw's `fs.credentials_dir.perms_writable` /
   `fs.sessions_store.perms_readable` / `fs.config.perms_world_readable` audit checks.
+
+## Architectures
+
+`linux/amd64` only, unlike the repo's other (multi-arch) images. `@openclaw/memory-lancedb`
+carries a large native library that makes the emulated (QEMU) `arm64` build exceed this image's
+build timeout; the target homelab node is x64/amd64, so `arm64` isn't built. Restore
+`linux/amd64,linux/arm64` in `test-build-openclaw.yaml`/`publish-openclaw.yaml` if a native
+`arm64` builder becomes available.

--- a/openclaw/docker-entrypoint.sh
+++ b/openclaw/docker-entrypoint.sh
@@ -1,20 +1,43 @@
 #!/bin/bash
 set -eo pipefail
 
-DATA_DIR="${OPENCLAW_DATA_DIR:-/home/node/.openclaw}"
+# All gateway-created state files/dirs land 600/700 so they don't trip OpenClaw's
+# fs.credentials_dir.perms_writable / fs.sessions_store.perms_readable audit checks on a
+# group-writable fsGroup-mounted PVC. (The state-dir *root* is the kubelet-owned fsGroup mount
+# point -- umask can't affect it, so fs.state_dir.perms_group_writable stays config-suppressed.)
+umask 077
 
-# The plugins installed at image build time (see Dockerfile) live under the OpenClaw data dir
-# (npm/projects/* + the pinned install records). Deployments commonly mount external storage
-# (a PVC, a bind mount) over that data dir for gateway state; a freshly-mounted volume starts
-# empty and hides everything baked into the image. Restore anything missing from the build-time
-# seed, with cp -n so existing content an operator persisted always wins.
+STATE_DIR="${OPENCLAW_STATE_DIR:-${OPENCLAW_DATA_DIR:-/home/node/.openclaw}}"
+
+# The plugins installed at image build time (see Dockerfile) live under the OpenClaw state dir
+# (npm/projects/* + the pinned install records). Deployments commonly mount external storage (a
+# PVC, a bind mount) over that dir for gateway state; a freshly-mounted volume starts empty and
+# hides everything baked into the image. Restore anything missing from the build-time seed, with
+# cp -n so content an operator persisted always wins.
 if [[ -d /home/node/.openclaw-seed ]]; then
-  if mkdir -p "${DATA_DIR}" 2>/dev/null; then
-    cp -an /home/node/.openclaw-seed/. "${DATA_DIR}/" 2>/dev/null \
-      || echo "docker-entrypoint: could not seed ${DATA_DIR}, continuing without it" >&2
+  if mkdir -p "${STATE_DIR}" 2>/dev/null; then
+    cp -an /home/node/.openclaw-seed/. "${STATE_DIR}/" 2>/dev/null \
+      || echo "docker-entrypoint: could not seed ${STATE_DIR}, continuing without it" >&2
   else
-    echo "docker-entrypoint: ${DATA_DIR} is not writable, continuing without seeding" >&2
+    echo "docker-entrypoint: ${STATE_DIR} is not writable, continuing without seeding" >&2
   fi
 fi
 
-exec node openclaw.mjs gateway "$@"
+# Seed the gateway config from a read-only source (e.g. a Kubernetes ConfigMap mount) into its
+# writable config path, so OpenClaw's CLI can write the file back (channels login, doctor) without
+# EBUSY against a read-only mount. Copy only if the target is absent (an in-place edit in a
+# writable volume wins), then tighten to 600 per the fs.config.perms_world_readable audit check.
+# This folds in the work a separate config-seed init container would otherwise do.
+CONFIG_SEED="${OPENCLAW_CONFIG_SEED:-}"
+CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-}"
+if [[ -n "${CONFIG_SEED}" && -f "${CONFIG_SEED}" && -n "${CONFIG_PATH}" && ! -e "${CONFIG_PATH}" ]]; then
+  if mkdir -p "$(dirname "${CONFIG_PATH}")" 2>/dev/null && cp "${CONFIG_SEED}" "${CONFIG_PATH}" 2>/dev/null; then
+    chmod 600 "${CONFIG_PATH}" 2>/dev/null || true
+  else
+    echo "docker-entrypoint: could not seed config ${CONFIG_PATH} from ${CONFIG_SEED}" >&2
+  fi
+fi
+
+# Exec the upstream gateway command supplied via CMD (kept in CMD, not hardcoded here, so it stays
+# explicit/overridable). The base image ENTRYPOINT (tini -s --) remains PID 1 for signal handling.
+exec "$@"


### PR DESCRIPTION
## Summary

- **Two more baked-in plugins**: extends the existing pinned plugin install chain
  (`whatsapp`, `diagnostics-prometheus`) with `@openclaw/memory-lancedb` (LanceDB-backed memory
  store) and `@openclaw/lobster` (action-approval gating), pinned to `2026.7.1` to match the base
  image. Neither is enabled by default — a deployment's config opts in.
- **Entrypoint wrapper hardening** (`docker-entrypoint.sh`, now invoked via `CMD` with the base
  image's `tini -s --` staying `ENTRYPOINT`/PID 1):
  - `umask 077` so everything the gateway creates under the state dir lands owner-only (600/700),
    clearing OpenClaw's `fs.credentials_dir.perms_writable` / `fs.sessions_store.perms_readable` /
    `fs.config.perms_world_readable` audit checks.
  - State seeding (unchanged in behavior, renamed var support: `OPENCLAW_STATE_DIR` falling back
    to the existing `OPENCLAW_DATA_DIR`): restores the build-time plugin/state seed into a
    mounted state dir with `cp -n`, so operator-persisted content always wins.
  - New config seeding: if `OPENCLAW_CONFIG_SEED` and `OPENCLAW_CONFIG_PATH` are both set and the
    target doesn't already exist, copies the seed in and `chmod 600`s it, so the gateway's own CLI
    can write the file back (channels login, doctor) without `EBUSY` against a read-only mount.
    This folds in what a separate config-seed init container would otherwise do. **Backwards
    compatible**: it's a no-op when `OPENCLAW_CONFIG_SEED` is unset, so the current deployment is
    unaffected until it opts in.
- **New report-only security scan** (`.github/workflows/scan-openclaw.yaml`): on PRs touching
  `openclaw/**`, a weekly schedule, and `workflow_dispatch`, builds the image (amd64) and runs
  Trivy (`vuln,secret,misconfig`, HIGH/CRITICAL, SARIF uploaded to the Security tab under category
  `trivy`, plus a human-readable table log), Dockle (CIS/best-practices), and a Syft SBOM
  (`spdx-json`, uploaded as a build artifact). Every scan/upload step is `continue-on-error: true`
  with exit-code `0` — this is a soft launch to build up findings before anything here gates a
  merge (see the comment at the top of the workflow for how to flip it later). Added an empty
  `.trivyignore` at repo root as the place to record triaged CVE suppressions once it does.

## Out of scope / follow-up

The deployment-side changes (drop the separate config-seed init container, mount the ConfigMap at
the wrapper's `OPENCLAW_CONFIG_SEED` path in the main container, remove the two now-cleared
fs-perms audit suppressions) happen **after** this image publishes, in the
`homelab-ops-kubernetes-clusters` repo — not part of this PR.

## Test plan

- [x] `pre-commit run` (hadolint, shellcheck, yamllint --strict, markdownlint, actionlint) clean
      on all changed files.
- [ ] CI: `test-build-openclaw` (multi-arch build), `lint`, and the new `scan-openclaw` all green.