### PR TITLE
fix(openclaw): re-tighten fsGroup-loosened state perms in the entrypoint on every start

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -16,7 +16,7 @@ not enabled unless a deployment's config turns them on.
 ## Entrypoint wrapper
 
 `docker-entrypoint.sh` (invoked via `CMD`, with the base image's `tini -s --` staying PID 1 as
-`ENTRYPOINT`) does three things before `exec`-ing the upstream gateway command:
+`ENTRYPOINT`) does four things before `exec`-ing the upstream gateway command:
 
 - **State seeding**: restores the build-time plugin/state seed (`/home/node/.openclaw-seed`)
   into the mounted state dir (`OPENCLAW_STATE_DIR`/`OPENCLAW_DATA_DIR`, default
@@ -30,9 +30,18 @@ not enabled unless a deployment's config turns them on.
   `OPENCLAW_CONFIG_SEED` is unset, so it's backwards-compatible with deployments that seed
   config another way (e.g. a separate init container). Copy-if-absent means an in-place edit in
   a writable volume always wins.
-- **`umask 077`**: everything the gateway creates under the state dir lands owner-only
-  (600/700), satisfying OpenClaw's `fs.credentials_dir.perms_writable` /
-  `fs.sessions_store.perms_readable` / `fs.config.perms_world_readable` audit checks.
+- **`umask 077`**: everything the gateway *creates* this boot lands owner-only (files 600, dirs
+  700), satisfying OpenClaw's `fs.config.perms_world_readable` audit check and keeping fresh
+  state tight.
+- **State perms re-tighten**: on a Kubernetes `fsGroup`-mounted PVC the kubelet re-adds group
+  `rw` to every existing file at each mount (before this container starts), which `umask` can't
+  prevent for state persisted from a prior boot — so the entrypoint recursively `chmod go-rwx`s
+  the sensitive `<state>/credentials` and `<state>/agents` trees on every start (uid 1000 owns
+  them, so it keeps owner access). This is what makes the fix stick across restarts and clears
+  `fs.credentials_dir.perms_writable` / `fs.auth_profiles.perms_writable` /
+  `fs.sessions_store.perms_readable`. The state-dir root stays group-writable (kubelet-owned
+  mount point, not chmod-able by uid 1000) and remains audit-suppressed by the deployment's
+  config.
 
 ## Architectures
 

--- a/openclaw/docker-entrypoint.sh
+++ b/openclaw/docker-entrypoint.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -eo pipefail
 
-# All gateway-created state files/dirs land 600/700 so they don't trip OpenClaw's
-# fs.credentials_dir.perms_writable / fs.sessions_store.perms_readable audit checks on a
-# group-writable fsGroup-mounted PVC. (The state-dir *root* is the kubelet-owned fsGroup mount
-# point -- umask can't affect it, so fs.state_dir.perms_group_writable stays config-suppressed.)
+# Files this process creates land 600/700 (dirs) so they don't trip OpenClaw's fs-perms audit
+# checks. umask alone isn't enough on a Kubernetes fsGroup-mounted PVC: the kubelet re-applies
+# group rw to every EXISTING file on the volume at each mount (before this container starts), so
+# state persisted from a prior boot comes back group-writable -- the chmod re-tighten step below
+# fixes that on every start. The state-dir ROOT stays group-writable regardless (it's the
+# kubelet-owned fsGroup mount point, chmod EPERM for uid 1000) and remains audit-suppressed
+# (fs.state_dir.perms_group_writable).
 umask 077
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-${OPENCLAW_DATA_DIR:-/home/node/.openclaw}}"
@@ -37,6 +40,22 @@ if [[ -n "${CONFIG_SEED}" && -f "${CONFIG_SEED}" && -n "${CONFIG_PATH}" && ! -e 
     echo "docker-entrypoint: could not seed config ${CONFIG_PATH} from ${CONFIG_SEED}" >&2
   fi
 fi
+
+# Re-tighten the uid-1000-owned sensitive state trees AFTER the kubelet's fsGroup mount (which
+# ran before this container started and re-added group rw to everything on the PVC, defeating
+# umask on files persisted from a prior boot). This is what makes the fixes stick across restarts
+# -- a manual chmod would be undone by the next mount. Covers, per OpenClaw's security audit:
+#   fs.credentials_dir.perms_writable   -> <state>/credentials             (dir 700)
+#   fs.auth_profiles.perms_writable     -> <state>/agents/*/agent/*.sqlite* (files 600)
+#   fs.sessions_store.perms_readable    -> <state>/agents/*/sessions/*.json (files 600)
+# `go-rwx` recursively strips group/other on these trees; uid 1000 owns them so it keeps access
+# via owner bits, and it doesn't touch the (kubelet-owned, un-chmod-able) state-dir root. The
+# large npm/plugin trees are left alone -- they aren't audited and don't need tightening.
+for tree in "${STATE_DIR}/credentials" "${STATE_DIR}/agents"; do
+  if [[ -d "${tree}" ]]; then
+    chmod -R go-rwx "${tree}" 2>/dev/null || true
+  fi
+done
 
 # Exec the upstream gateway command supplied via CMD (kept in CMD, not hardcoded here, so it stays
 # explicit/overridable). The base image ENTRYPOINT (tini -s --) remains PID 1 for signal handling.


### PR DESCRIPTION
## Problem
On the live deployment, `openclaw security audit` re-flags 4 CRITICAL + 1 WARN fs-perms findings after every pod restart, even though the entrypoint sets `umask 077`:

```
CRITICAL  /home/node/.openclaw/credentials                             mode=770
CRITICAL  /home/node/.openclaw/agents/main/agent/openclaw-agent.sqlite mode=660 (+ -wal, -shm)
WARN      /home/node/.openclaw/agents/main/sessions/sessions.json      mode=660
```

**Root cause:** Kubernetes `fsGroup` re-applies group `rw` to *every existing file* on the PVC at each mount — which runs *before* the container starts — so `umask` (which only governs newly-created files) can't keep state persisted from a prior boot tight. A manual `chmod` is undone by the next mount.

## Fix
After the fsGroup mount (i.e. in the entrypoint, on every start), recursively `chmod go-rwx` the uid-1000-owned sensitive trees — `<state>/credentials` and `<state>/agents` — so the fix re-applies on every boot and sticks. uid 1000 owns them, so it keeps access via owner bits; the large npm/plugin trees are left alone (not audited). Clears:
- `fs.credentials_dir.perms_writable` (dir → 700)
- `fs.auth_profiles.perms_writable` (auth SQLite → 600)
- `fs.sessions_store.perms_readable` (sessions.json → 600)

The state-dir **root** stays group-writable — it's the kubelet-owned fsGroup mount point (`chmod` EPERM for uid 1000) — and remains audit-suppressed by the deployment config (`fs.state_dir.perms_group_writable`), unchanged.

## Rollout
New digest → bump the `apps-ai` module's openclaw image pin → new `apps-ai` release → bump the cluster's source tag. (Same cascade as the wrapper build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyhJGPFxahn68H5Kv35obL
