### PR TITLE
feat(obsidian): headless Obsidian image with Local REST API baked in and auto-trusted

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,7 @@
     "github>ppat/images//.github/renovate/image-updates",
     "github>ppat/images//.github/renovate/image-updates-bitwarden-cli",
     "github>ppat/images//.github/renovate/image-updates-freeradius-server",
+    "github>ppat/images//.github/renovate/image-updates-obsidian",
     "github>ppat/images//.github/renovate/image-updates-openclaw",
     "github>ppat/images//.github/renovate/aqua-cli-tools",
     "github>ppat/images//.github/renovate/aqua-registry"

--- a/.github/renovate/image-updates-obsidian.json
+++ b/.github/renovate/image-updates-obsidian.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "image-updates | all | obsidian | configure labels and semantic commit scope",
+      "addLabels": [
+        "image:obsidian"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "coddingtonbear/obsidian-local-rest-api",
+        "obsidianmd/obsidian-releases"
+      ],
+      "semanticCommitScope": "obsidian"
+    }
+  ]
+}

--- a/.github/workflows/publish-obsidian.yaml
+++ b/.github/workflows/publish-obsidian.yaml
@@ -1,0 +1,27 @@
+---
+# yamllint disable rule:line-length
+name: publish-obsidian
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - obsidian/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/release-workflow.yaml
+    secrets: inherit
+    with:
+      image_name: obsidian
+      platforms: linux/amd64,linux/arm64
+      source_git_ref: ${{ github.ref }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -1,0 +1,42 @@
+---
+# yamllint disable rule:line-length
+name: test-build-obsidian
+
+on:
+  pull_request:
+    paths:
+    - 'obsidian/**'
+    - '.github/workflows/test-build-obsidian.yaml'
+    - '.github/workflows/build-image-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  load-image-metadata:
+    uses: ./.github/workflows/load-metadata.yaml
+    with:
+      image_name: 'obsidian'
+
+  test-build-obsidian:
+    needs: [load-image-metadata]
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    with:
+      image_context_path: obsidian
+      label_title: ${{ needs.load-image-metadata.outputs.label_title }}
+      label_description: ${{ needs.load-image-metadata.outputs.label_description }}
+      platforms: linux/amd64,linux/arm64
+      private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/obsidian
+      private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/obsidian
+      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
+    secrets:
+      private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+      private_registry_token: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+      private_registry: ${{ secrets.CONTAINER_REGISTRY }}
+      tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+      tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and [CLAUDE.md](CLAUDE.md) for build/lint commands.
 | [bitwarden-cli](./bitwarden-cli/) | [![test-build-bitwarden-cli](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-bitwarden-cli.yaml) |
 | [tools](./tools/) | [![test-tools](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-tools.yaml) |
 | [freeradius-server](./freeradius-server/) | [![test-build-freeradius-server](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-freeradius-server.yaml) |
+| [obsidian](./obsidian/) | [![test-build-obsidian](https://github.com/ppat/images/actions/workflows/test-build-obsidian.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-obsidian.yaml) |
 | [openclaw](./openclaw/) | [![test-build-openclaw](https://github.com/ppat/images/actions/workflows/test-build-openclaw.yaml/badge.svg)](https://github.com/ppat/images/actions/workflows/test-build-openclaw.yaml) |
 
 ## Releases

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,6 +40,7 @@ module.exports = {
         'dev-tools',
         'freeradius-server',
         'github-actions',
+        'obsidian',
         'openclaw',
         'release',
         'renovate',

--- a/obsidian/Dockerfile
+++ b/obsidian/Dockerfile
@@ -1,0 +1,162 @@
+# =======================================================================================================================================
+# Builder stage. Runs on the BUILD platform: everything it does is a network fetch plus a tar
+# extraction, and Obsidian ships a per-arch plain tarball of its Electron app directory
+# (obsidian-<ver>.tar.gz / obsidian-<ver>-arm64.tar.gz). Fetching the tarball rather than the
+# AppImage is deliberate -- an AppImage has to either be executed (`--appimage-extract`, which
+# needs a matching-arch interpreter and would therefore drag the arm64 build under QEMU
+# emulation) or mounted via libfuse (which needs FUSE in the container). The tarball has neither
+# problem and its contents are byte-identical to what the AppImage unpacks to, so the arm64
+# image is assembled without emulating a single instruction here.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818 AS builder
+ARG TARGETARCH
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /tmp
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt,id=obsidian-cache-apt-builder \
+    --mount=type=cache,target=/var/cache/debconf,id=obsidian-cache-debconf-builder \
+    --mount=type=cache,target=/var/lib/apt,id=obsidian-lib-apt-builder \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -yq --no-install-recommends \
+        ca-certificates \
+        curl
+
+# renovate: datasource=github-releases depName=obsidianmd/obsidian-releases
+ARG OBSIDIAN_VERSION="1.12.7"
+RUN --mount=type=tmpfs,target=/tmp \
+    case "${TARGETARCH}" in \
+        amd64) ARCH_SUFFIX="" ;; \
+        arm64) ARCH_SUFFIX="-arm64" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL -o /tmp/obsidian.tar.gz \
+        "https://github.com/obsidianmd/obsidian-releases/releases/download/v${OBSIDIAN_VERSION}/obsidian-${OBSIDIAN_VERSION}${ARCH_SUFFIX}.tar.gz" && \
+    mkdir -p /opt/obsidian && \
+    tar -xzf /tmp/obsidian.tar.gz -C /opt/obsidian --strip-components=1 && \
+    test -x /opt/obsidian/obsidian
+
+# The Local REST API plugin is what the whole image exists to serve: it's the only way anything
+# outside this container is allowed to touch the vault. Upstream publishes the three built plugin
+# artifacts as GitHub release assets, so baking it in is a download, not a build from source.
+# These land in a seed directory rather than straight into the vault because the vault is an
+# externally-mounted volume at runtime -- see docker-entrypoint.sh for how the seed is applied.
+# renovate: datasource=github-releases depName=coddingtonbear/obsidian-local-rest-api
+ARG LOCAL_REST_API_VERSION="5.0.2"
+RUN mkdir -p /opt/obsidian-seed/plugins/obsidian-local-rest-api && \
+    for asset in main.js manifest.json styles.css; do \
+        curl -fsSL -o "/opt/obsidian-seed/plugins/obsidian-local-rest-api/${asset}" \
+            "https://github.com/coddingtonbear/obsidian-local-rest-api/releases/download/${LOCAL_REST_API_VERSION}/${asset}"; \
+    done && \
+    grep -q '"id": "obsidian-local-rest-api"' /opt/obsidian-seed/plugins/obsidian-local-rest-api/manifest.json
+
+
+# =======================================================================================================================================
+# Final stage. Debian rather than Alpine because Obsidian is a stock glibc-linked Electron build;
+# it is not rebuilt against musl and there is no upstream musl artifact.
+#
+# Deliberately NOT derived from linuxserver/obsidian or sytone/obsidian-remote. Both are the same
+# vanilla-binary pattern on a desktop-streaming base (selkies / KasmVNC) whose GUI ships with
+# passwordless sudo -- linuxserver's own README says anyone reaching the GUI is root in the
+# container. This container holds the read-write mount of the authoritative vault and its GUI is
+# deliberately reachable for configuration and repair, so inheriting that is not acceptable.
+# Building from scratch also drops s6-overlay, the start-as-root-then-drop dance, and a
+# continuously-running desktop stack we don't need. The cost is owning the Electron dependency
+# set below, which is bounded: it is exactly the DT_NEEDED list of /opt/obsidian/obsidian.
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+ARG TARGETARCH
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /
+
+ARG OBSIDIAN_UID=1000
+ARG OBSIDIAN_GID=1000
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# The libs below are the resolved Debian packages for the shared objects Obsidian's Electron
+# binary actually links against (readelf -d /opt/obsidian/obsidian), plus:
+#   - xvfb            the virtual display Obsidian renders into; there is no real one here
+#   - x11vnc          installed but never started -- see README, "GUI access"
+#   - python3-websocket  the Chrome DevTools Protocol client used by auto-trust.py speaks
+#                     WebSocket; Debian packages websocket-client so nothing needs pip at build
+#                     or run time
+#   - libsecret-1-0   dlopen()ed by Electron's safeStorage; absent it logs and degrades
+#   - fonts-dejavu-core  without any font installed the GUI renders empty boxes, which matters
+#                     only for the occasional operator VNC session but is cheap to prevent
+#   - tini            this image owns PID 1 (no s6-overlay, no init supervisor); tini reaps the
+#                     Xvfb/auto-trust children the entrypoint backgrounds and forwards signals
+RUN --mount=type=cache,target=/var/cache/apt,id=obsidian-cache-apt-${TARGETARCH} \
+    --mount=type=cache,target=/var/cache/debconf,id=obsidian-cache-debconf-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,id=obsidian-lib-apt-${TARGETARCH} \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -yq --no-install-recommends \
+        ca-certificates \
+        curl \
+        fonts-dejavu-core \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libgbm1 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libsecret-1-0 \
+        libudev1 \
+        libx11-6 \
+        libxcb1 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxkbcommon0 \
+        libxrandr2 \
+        python3 \
+        python3-websocket \
+        tini \
+        x11vnc \
+        xvfb
+
+RUN groupadd -g $OBSIDIAN_GID -r obsidian && \
+    useradd -u $OBSIDIAN_UID \
+        -g obsidian \
+        --system \
+        --create-home \
+        --home-dir /home/obsidian \
+        --no-log-init \
+        --shell /usr/sbin/nologin \
+        obsidian
+
+COPY --from=builder --chown=root:root /opt/obsidian /opt/obsidian
+COPY --from=builder --chown=root:root /opt/obsidian-seed /opt/obsidian-seed
+COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chown=root:root --chmod=755 auto-trust.py /usr/local/bin/auto-trust.py
+
+# /vault is the vault itself (a volume at runtime); /config is Electron's userData directory,
+# which holds obsidian.json AND the localStorage LevelDB where Obsidian records that community
+# plugins are trusted -- persist it or the auto-trust step (which is idempotent, so this is a
+# cost not a correctness problem) has to redo its work on every restart.
+RUN install -d -o obsidian -g obsidian -m 0750 /vault /config
+
+ENV XDG_CONFIG_HOME=/config \
+    XDG_CACHE_HOME=/home/obsidian/.cache \
+    OBSIDIAN_VAULT_DIR=/vault \
+    DISPLAY=:99 \
+    OBSIDIAN_SCREEN_GEOMETRY=1920x1080x24
+
+# 27124 is the plugin's HTTPS listener (self-signed cert generated by the plugin on first run).
+# The plaintext listener on 27123 is left disabled -- the plugin defaults it off and nothing in
+# this design needs it. Note that 9222 (Chrome DevTools Protocol, used by auto-trust.py) is
+# NOT exposed and Chromium binds it to 127.0.0.1 only.
+EXPOSE 27124
+
+USER obsidian
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]

--- a/obsidian/Dockerfile
+++ b/obsidian/Dockerfile
@@ -15,14 +15,27 @@ WORKDIR /tmp
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-RUN --mount=type=cache,target=/var/cache/apt,id=obsidian-cache-apt-builder \
-    --mount=type=cache,target=/var/cache/debconf,id=obsidian-cache-debconf-builder \
-    --mount=type=cache,target=/var/lib/apt,id=obsidian-lib-apt-builder \
+# Cache mount ids carry ${TARGETARCH}: buildx instantiates this stage once per target platform
+# and cache mounts default to sharing=shared, so a single id would put two concurrent apt runs on
+# the same /var/lib/apt and one of them would die on the lock.
+RUN --mount=type=cache,target=/var/cache/apt,id=obsidian-cache-apt-builder-${TARGETARCH} \
+    --mount=type=cache,target=/var/cache/debconf,id=obsidian-cache-debconf-builder-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,id=obsidian-lib-apt-builder-${TARGETARCH} \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -yq --no-install-recommends \
         ca-certificates \
         curl
 
+# STABLE channel, deliberately. Obsidian also has a beta/insider channel (1.13.x at time of
+# writing) and some community plugins already declare minAppVersion 1.13.0 -- Templater and
+# QuickAdd among them -- so a future maintainer will eventually be tempted to bump this to beta to
+# make a plugin load. Don't, without re-taking the decision: this container is the single writer
+# of the authoritative vault and the component everything else in the system stands on, and
+# tracking a pre-release channel there trades that stability for plugins whose value is to a human
+# sitting at the GUI. The REST API plugin this image exists to serve declares minAppVersion 1.8.7,
+# so the critical path has room to spare on stable.
+# Renovate can't drift this onto beta on its own: insider builds are not published as GitHub
+# releases in obsidianmd/obsidian-releases at all, so the datasource below only ever sees stable.
 # renovate: datasource=github-releases depName=obsidianmd/obsidian-releases
 ARG OBSIDIAN_VERSION="1.12.7"
 RUN --mount=type=tmpfs,target=/tmp \

--- a/obsidian/README.md
+++ b/obsidian/README.md
@@ -1,0 +1,147 @@
+# obsidian
+
+A headless [Obsidian](https://obsidian.md/) image: the stock Electron desktop app running against
+a virtual display, with [`obsidian-local-rest-api`](https://github.com/coddingtonbear/obsidian-local-rest-api)
+baked in and turned on automatically, so a vault can be read and written over HTTP by something
+outside the container while exactly one process (this one) ever touches the vault's files.
+
+A VNC server is installed but never started, so an operator can attach to the *same* running
+Obsidian instance on demand for the settings that are only reachable through the GUI.
+
+## Why this image is built from scratch
+
+`linuxserver/obsidian` and `sytone/obsidian-remote` both ship a stock Obsidian binary with no
+plugins and no vault, on a desktop-streaming base image whose GUI has passwordless `sudo` —
+linuxserver's own README says so. This container holds the read-write mount of an authoritative
+vault and its GUI is deliberately reachable for configuration and repair, so inheriting a
+root-from-the-GUI path is not acceptable. Building on plain `debian:bookworm-slim` also drops
+s6-overlay, the start-as-root-then-drop-privileges dance, and a continuously running desktop
+stack. The cost is owning the Electron dependency set, which is bounded — it is exactly the
+`DT_NEEDED` list of the shipped binary, enumerated in the `Dockerfile`.
+
+Obsidian itself is installed from the per-architecture `.tar.gz` release asset rather than the
+AppImage: an AppImage has to be executed (`--appimage-extract`) or FUSE-mounted to unpack, and
+executing it would force the `arm64` build under QEMU emulation. The tarball unpacks to the same
+tree with neither constraint.
+
+## Auto-trust: why there is a Chrome DevTools Protocol client in here
+
+Obsidian will not load a community plugin until the vault is trusted (Restricted Mode off), and
+**that flag is not a file**. It lives in the Electron renderer's `localStorage` under a key
+derived from a per-install app id — not in the vault, not in `.obsidian/`, not in
+`obsidian.json`. Installing the plugin's files and listing its id in
+`.obsidian/community-plugins.json` is necessary but *not sufficient*: the plugin sits there
+enabled on paper and never loads, and the REST API never binds.
+
+So the entrypoint starts Obsidian with `--remote-debugging-port=9222 --remote-allow-origins=*`
+(Chromium binds that port to `127.0.0.1` only, and it is not `EXPOSE`d), and `auto-trust.py`
+attaches over the Chrome DevTools Protocol and calls the same runtime API the GUI's trust toggle
+calls — `app.plugins.setEnable(true)` — then enables the plugin if it isn't already. It runs on
+every start and is idempotent, which also means it self-heals a container whose `/config` volume
+was lost or replaced. The technique is the one demonstrated by
+[`shanehull/obsidian-remote`](https://github.com/shanehull/obsidian-remote)'s `auto-trust.sh`
+(GPL-3.0; referenced for the approach, implemented independently here).
+
+The debugging port stays open for the life of the process. Closing it would mean restarting
+Obsidian after trust is established, which would mean a second Obsidian launch and a supervisor
+to sequence it — against the one-process design. It is loopback-only inside a single-purpose
+container, so the only things that can reach it are the other processes this image starts.
+
+## What the entrypoint does
+
+`docker-entrypoint.sh` runs under `tini` as PID 1 (no s6-overlay, no init supervisor, no `sudo`)
+and, as uid 1000:
+
+- **Installs the plugin into the vault.** `/vault` and `/config` are external volumes at runtime,
+  so anything baked into those paths would be shadowed by the mount; everything baked in lives
+  under `/opt/obsidian-seed` and is applied at start. `main.js`/`manifest.json`/`styles.css` are
+  overwritten unconditionally — plugin code tracks the image, and copy-if-absent would mean a
+  Renovate version bump never reached a vault that had already been started once. The plugin's
+  own `data.json` (API key and settings) is never overwritten.
+- **Merges** the plugin id into `.obsidian/community-plugins.json`, preserving any other plugins
+  an operator enabled through the GUI.
+- **Registers the vault** in `${XDG_CONFIG_HOME}/obsidian/obsidian.json` if that file is absent,
+  with a vault id derived from the vault path so it is stable if `/config` is lost. This does not
+  establish trust; it only makes Obsidian open the vault instead of the vault picker.
+- **Pins the REST API key** from `OBSIDIAN_API_KEY` if that variable is set (see below), then
+  `chmod 0600`s `data.json` on every start — a Kubernetes `fsGroup` mount re-adds group `rw` to
+  every existing file before the container starts, so a one-off `chmod` would not survive.
+- **Starts `Xvfb`** on `$DISPLAY` and waits for its socket.
+- **Starts `auto-trust.py`** in the background (it polls, so starting it before Obsidian is fine).
+- **`exec`s Obsidian**, which becomes the container's long-running process.
+
+`umask 0027`: files this container creates are owner read-write, `fsGroup` read-only, nothing for
+world. Group-**read** rather than group-write is deliberate — a sidecar sharing the volume (a git
+syncer, say) can read and commit, but the single-writer invariant stays structurally enforced.
+
+## Configuration
+
+| variable | default | purpose |
+| --- | --- | --- |
+| `OBSIDIAN_VAULT_DIR` | `/vault` | vault to open; mount the vault volume here |
+| `XDG_CONFIG_HOME` | `/config` | Electron `userData`; holds `obsidian.json` and the `localStorage` LevelDB that records the trust flag |
+| `OBSIDIAN_API_KEY` | *(unset)* | pins the REST API key instead of letting the plugin generate a random one; unset means the plugin owns its own key |
+| `OBSIDIAN_SCREEN_GEOMETRY` | `1920x1080x24` | `Xvfb` screen geometry |
+| `DISPLAY` | `:99` | X display for both Obsidian and an on-demand `x11vnc` |
+| `OBSIDIAN_CDP_PORT` | `9222` | loopback DevTools port used by auto-trust |
+
+`/config` should be persisted. Everything still works if it is not — auto-trust re-runs — but
+application settings and the trust flag are re-established from scratch on every start.
+
+`/home/obsidian` (Electron cache) and `/tmp` (X11 socket, Chromium shared memory) must be
+writable; with a read-only root filesystem, give both an `emptyDir`.
+
+## Health
+
+Port `27124` is the plugin's HTTPS listener, with a self-signed certificate the plugin generates
+itself. Its root endpoint answers without authentication, and it only binds once the vault is
+open *and* trusted *and* the plugin has loaded — so it is a far better readiness signal than the
+process existing:
+
+```yaml
+readinessProbe:
+  httpGet:
+    scheme: HTTPS
+    port: 27124
+    path: /
+```
+
+`httpGet` with `scheme: HTTPS` does not verify the certificate, so the self-signed cert is fine.
+The plaintext listener on `27123` is left disabled — the plugin defaults it off and nothing here
+needs it.
+
+## GUI access
+
+The GUI is for the handful of settings that are only reachable through it — property types,
+default location for new notes, attachment folder, daily-note format, template folder — and for
+repair. It is off by default and attaches to the *already running* Obsidian process; there is no
+second entrypoint mode and no second deployment, because two Obsidian processes against one vault
+would break the single-writer invariant.
+
+1. Start `x11vnc` against the display Obsidian is already using:
+
+    ```bash
+    kubectl exec -it deploy/<deployment> -c obsidian -- \
+      x11vnc -display :99 -localhost -rfbport 5900 -nopw -shared -forever
+    ```
+
+    `-localhost` binds `127.0.0.1` only. `-nopw` is safe *because of* `-localhost`: the port is
+    reachable only from inside the pod's network namespace, which is exactly what
+    `kubectl port-forward` connects to. Nothing on the cluster network can reach it.
+
+2. In another terminal, forward the port:
+
+    ```bash
+    kubectl port-forward deploy/<deployment> 5900:5900
+    ```
+
+3. Point a VNC viewer at `localhost:5900`.
+
+4. When finished, stop `x11vnc` with `Ctrl-C` in the `kubectl exec` terminal. Obsidian keeps
+   running; only the viewer goes away.
+
+## Architectures
+
+`linux/amd64` and `linux/arm64`. Both the Obsidian tarball and the plugin's release assets are
+fetched and unpacked in a `--platform=$BUILDPLATFORM` builder stage, so the `arm64` image is
+assembled without QEMU emulating anything — only `apt-get install` runs under emulation.

--- a/obsidian/auto-trust.py
+++ b/obsidian/auto-trust.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Turn Obsidian's Restricted Mode off from outside the GUI, then wait for the REST API.
+
+Why this exists, because it will look bizarre otherwise
+------------------------------------------------------
+Obsidian will not load a community plugin until the vault is "trusted" (Restricted Mode off).
+That flag is NOT a file: it lives in the Electron renderer's localStorage, under a key derived
+from a per-install app id. It is not in the vault, not in `.obsidian/`, and not in
+`obsidian.json`. So copying the plugin's `main.js`/`manifest.json` into
+`.obsidian/plugins/<id>/` and listing the id in `.obsidian/community-plugins.json` -- which the
+entrypoint does, and which is necessary -- is not sufficient. Without the step below the plugin
+sits on disk, enabled on paper, and never loads; the REST API never binds; nothing works.
+
+The only known headless way to flip it is to talk to the running renderer. Obsidian is Electron,
+so the entrypoint starts it with `--remote-debugging-port=9222 --remote-allow-origins=*`
+(Chromium binds that port to 127.0.0.1 only), and this script attaches over the Chrome DevTools
+Protocol and calls the exact same runtime API the GUI's own trust toggle calls:
+`app.plugins.setEnable(true)`. The technique is the one demonstrated by
+shanehull/obsidian-remote's `auto-trust.sh` (GPL-3.0 -- referenced for the approach, implemented
+independently here).
+
+This is idempotent by construction: `setEnable(true)` on an already-trusted vault is a no-op, and
+the plugin is only enabled if it isn't already. It therefore runs unconditionally on every start,
+which also means it self-heals a vault whose `/config` volume was lost or replaced.
+"""
+
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import websocket
+
+CDP_URL = os.environ.get("OBSIDIAN_CDP_URL", "http://127.0.0.1:9222")
+REST_API_URL = os.environ.get("OBSIDIAN_REST_API_URL", "https://127.0.0.1:27124/")
+PLUGIN_ID = os.environ.get("OBSIDIAN_PLUGIN_ID", "obsidian-local-rest-api")
+
+CDP_WAIT_SECONDS = int(os.environ.get("OBSIDIAN_CDP_WAIT_SECONDS", "120"))
+APP_WAIT_SECONDS = int(os.environ.get("OBSIDIAN_APP_WAIT_SECONDS", "120"))
+REST_API_WAIT_SECONDS = int(os.environ.get("OBSIDIAN_REST_API_WAIT_SECONDS", "120"))
+
+# Enable community plugins (== turn Restricted Mode off), then make sure our specific plugin is
+# on. `enablePluginAndSave` also rewrites .obsidian/community-plugins.json, so the two sources of
+# truth stay consistent even if an operator edited one of them by hand. The modal close at the
+# end dismisses Obsidian's "this vault contains community plugins" dialog if it appeared, so an
+# operator opening the GUI later doesn't land on a stale dialog. It clicks the *close* control,
+# never a confirm button -- blind-clicking modal buttons in someone's vault is not acceptable.
+ENABLE_EXPRESSION = """
+(async () => {
+    const id = %s;
+    await app.plugins.setEnable(true);
+    if (!app.plugins.enabledPlugins.has(id)) {
+        await app.plugins.enablePluginAndSave(id);
+    }
+    document.querySelectorAll('.modal-close-button').forEach((b) => b.click());
+    return JSON.stringify({
+        enabled: Array.from(app.plugins.enabledPlugins),
+        loaded: Object.keys(app.plugins.plugins),
+    });
+})()
+""" % json.dumps(PLUGIN_ID)
+
+
+def log(message):
+    print("auto-trust: %s" % message, flush=True)
+
+
+def fail(message):
+    print("auto-trust: %s" % message, file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def http_get_json(url, timeout=5):
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_renderer_target():
+    """Return the WebSocket debugger URL of Obsidian's renderer page."""
+    deadline = time.monotonic() + CDP_WAIT_SECONDS
+    last_error = "no page target"
+    while time.monotonic() < deadline:
+        try:
+            targets = http_get_json("%s/json/list" % CDP_URL)
+            # Obsidian's renderer is served from app://obsidian.md/index.html. Match on that
+            # rather than taking the first page, so a devtools/about:blank target can't win.
+            for target in targets:
+                if target.get("type") == "page" and "obsidian.md" in target.get("url", ""):
+                    return target["webSocketDebuggerUrl"]
+        except (urllib.error.URLError, OSError, ValueError) as error:
+            last_error = repr(error)
+        time.sleep(2)
+    fail("timed out after %ss waiting for the Obsidian renderer on CDP (%s)" % (CDP_WAIT_SECONDS, last_error))
+
+
+class CdpSession:
+    def __init__(self, ws_url):
+        # suppress_origin: Chromium rejects a DevTools WebSocket carrying a non-null Origin
+        # unless --remote-allow-origins matches it. The entrypoint passes `*`, but not sending an
+        # Origin at all keeps this working even if that flag is ever tightened.
+        self._ws = websocket.create_connection(ws_url, timeout=30, suppress_origin=True)
+        self._seq = 0
+
+    def evaluate(self, expression):
+        self._seq += 1
+        request_id = self._seq
+        self._ws.send(json.dumps({
+            "id": request_id,
+            "method": "Runtime.evaluate",
+            "params": {"expression": expression, "awaitPromise": True, "returnByValue": True},
+        }))
+        # Responses are interleaved with unsolicited protocol events; keep reading until ours.
+        while True:
+            message = json.loads(self._ws.recv())
+            if message.get("id") == request_id:
+                return message
+
+    def close(self):
+        try:
+            self._ws.close()
+        except OSError:
+            pass
+
+
+def evaluated_value(message):
+    if "error" in message:
+        raise RuntimeError("CDP error: %s" % message["error"])
+    result = message.get("result", {})
+    if "exceptionDetails" in result:
+        raise RuntimeError("evaluation threw: %s" % result["exceptionDetails"])
+    return result.get("result", {}).get("value")
+
+
+def wait_for_app(session):
+    deadline = time.monotonic() + APP_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        # `app` only exists once the vault (not the vault picker) is open, which is the point at
+        # which app.plugins is real. Poll rather than sleeping a fixed amount: vault open time
+        # scales with vault size and with how contended the node is.
+        ready = evaluated_value(session.evaluate("typeof app !== 'undefined' && !!app.plugins && !!app.vault"))
+        if ready is True:
+            return
+        time.sleep(2)
+    fail("timed out after %ss waiting for the Obsidian app object (is the vault open?)" % APP_WAIT_SECONDS)
+
+
+def wait_for_rest_api():
+    """The REST API answering is the only real proof this worked end to end."""
+    # The plugin generates its own self-signed certificate, so verification is meaningless here
+    # and the connection never leaves the loopback interface.
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    deadline = time.monotonic() + REST_API_WAIT_SECONDS
+    last_error = "never answered"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(REST_API_URL, timeout=5, context=context) as response:
+                log("REST API is up (%s -> HTTP %s)" % (REST_API_URL, response.status))
+                return
+        except urllib.error.HTTPError as error:
+            # Any HTTP status means the listener is bound and serving, which is what we're after.
+            log("REST API is up (%s -> HTTP %s)" % (REST_API_URL, error.code))
+            return
+        except (urllib.error.URLError, OSError) as error:
+            last_error = repr(error)
+        time.sleep(2)
+    fail("timed out after %ss waiting for the REST API on %s (%s)" % (REST_API_WAIT_SECONDS, REST_API_URL, last_error))
+
+
+def main():
+    log("waiting for the Obsidian renderer on %s" % CDP_URL)
+    ws_url = wait_for_renderer_target()
+
+    session = CdpSession(ws_url)
+    try:
+        wait_for_app(session)
+        log("enabling community plugins and %s" % PLUGIN_ID)
+        state = evaluated_value(session.evaluate(ENABLE_EXPRESSION))
+        log("plugin state: %s" % state)
+    except RuntimeError as error:
+        fail(str(error))
+    finally:
+        session.close()
+
+    wait_for_rest_api()
+    log("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/obsidian/docker-entrypoint.sh
+++ b/obsidian/docker-entrypoint.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+set -eo pipefail
+
+# Files this process creates land 0640/0750: owner (uid 1000, the only writer) read-write, the
+# pod's fsGroup read-only, nothing for world. Group-read rather than group-write is deliberate
+# and load-bearing -- the design's cardinal invariant is that exactly one process ever writes the
+# vault's files, so a sidecar sharing the volume can read/commit but cannot author. umask alone
+# isn't enough on a Kubernetes fsGroup-mounted PVC: the kubelet re-applies group rw to every
+# EXISTING file at each mount, before this container starts, so anything persisted from a prior
+# boot comes back group-writable. That's harmless for notes but not for the plugin's data.json,
+# which holds the REST API key -- the explicit chmod further down re-tightens it every start.
+umask 0027
+
+VAULT_DIR="${OBSIDIAN_VAULT_DIR:-/vault}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-/config}"
+PLUGIN_ID="${OBSIDIAN_PLUGIN_ID:-obsidian-local-rest-api}"
+GEOMETRY="${OBSIDIAN_SCREEN_GEOMETRY:-1920x1080x24}"
+CDP_PORT="${OBSIDIAN_CDP_PORT:-9222}"
+
+SEED_PLUGIN_DIR="/opt/obsidian-seed/plugins/${PLUGIN_ID}"
+VAULT_PLUGIN_DIR="${VAULT_DIR}/.obsidian/plugins/${PLUGIN_ID}"
+ELECTRON_CONFIG_DIR="${CONFIG_DIR}/obsidian"
+
+log() {
+  echo "docker-entrypoint: $*"
+}
+
+die() {
+  echo "docker-entrypoint: $*" >&2
+  exit 1
+}
+
+# ----------------------------------------------------------------------------------------------
+# Vault and plugin seeding
+#
+# At runtime both ${VAULT_DIR} and ${CONFIG_DIR} are external volumes mounted over whatever the
+# image put there, so nothing plugin-related can simply be baked into its final location -- the
+# mount would shadow it. Everything baked in lives under /opt/obsidian-seed and is applied here.
+# ----------------------------------------------------------------------------------------------
+mkdir -p "${VAULT_PLUGIN_DIR}" "${ELECTRON_CONFIG_DIR}" \
+  || die "cannot write to ${VAULT_DIR} / ${CONFIG_DIR}; both must be writable by uid $(id -u)"
+
+# Plugin code tracks the IMAGE, not the volume, so this overwrites unconditionally. This is a
+# deliberate departure from the copy-if-absent seeding the openclaw image uses: main.js/
+# manifest.json/styles.css are build artifacts pinned by a Renovate-tracked version in the
+# Dockerfile, and copy-if-absent would mean a plugin version bump never actually reached any
+# vault that had already been started once. The plugin's own state -- data.json, which holds the
+# generated API key and settings -- is NOT in this list and is never overwritten.
+install -m 0640 \
+  "${SEED_PLUGIN_DIR}/main.js" \
+  "${SEED_PLUGIN_DIR}/manifest.json" \
+  "${SEED_PLUGIN_DIR}/styles.css" \
+  "${VAULT_PLUGIN_DIR}/" \
+  || die "failed to install the ${PLUGIN_ID} plugin into ${VAULT_PLUGIN_DIR}"
+log "installed ${PLUGIN_ID} $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' \
+  "${VAULT_PLUGIN_DIR}/manifest.json") into ${VAULT_PLUGIN_DIR}"
+
+# Obsidian reads the set of enabled community plugins from this file. Merge rather than write:
+# an operator may have enabled other plugins through the GUI and we must not drop them.
+python3 - "${VAULT_DIR}/.obsidian/community-plugins.json" "${PLUGIN_ID}" <<'PY'
+import json
+import os
+import sys
+
+path, plugin_id = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as handle:
+        plugins = json.load(handle)
+    if not isinstance(plugins, list):
+        plugins = []
+except (OSError, ValueError):
+    plugins = []
+
+if plugin_id not in plugins:
+    plugins.append(plugin_id)
+    with open(path, "w") as handle:
+        json.dump(plugins, handle, indent=2)
+    print("docker-entrypoint: added %s to %s" % (plugin_id, os.path.basename(path)))
+PY
+
+# obsidian.json is Electron-side (not vault-side) state listing the vaults Obsidian knows about.
+# Written only when absent, so anything an operator does in the GUI afterwards wins. The vault id
+# is derived from the path rather than random so it stays stable if ${CONFIG_DIR} is ever lost.
+# Note this file does NOT establish trust -- the Restricted Mode flag lives in the renderer's
+# localStorage and is dealt with by auto-trust.py. This only makes Obsidian open the vault.
+OBSIDIAN_JSON="${ELECTRON_CONFIG_DIR}/obsidian.json"
+if [[ ! -e "${OBSIDIAN_JSON}" ]]; then
+  VAULT_ID="$(printf '%s' "${VAULT_DIR}" | md5sum | cut -c1-16)"
+  printf '{"vaults":{"%s":{"path":"%s","ts":%s,"open":true}}}\n' \
+    "${VAULT_ID}" "${VAULT_DIR}" "$(date +%s%3N)" > "${OBSIDIAN_JSON}"
+  log "registered ${VAULT_DIR} as vault ${VAULT_ID} in ${OBSIDIAN_JSON}"
+fi
+
+# The plugin generates a random API key the first time it's enabled, which leaves the key
+# discoverable only by exec-ing into a running container -- awkward to wire a client up to
+# declaratively. Setting OBSIDIAN_API_KEY (e.g. from a Kubernetes Secret) pins it instead. Opt-in:
+# unset, the plugin keeps generating and owning its own key. Merged into any existing data.json so
+# settings an operator changed in the GUI survive.
+DATA_JSON="${VAULT_PLUGIN_DIR}/data.json"
+if [[ -n "${OBSIDIAN_API_KEY}" ]]; then
+  python3 - "${DATA_JSON}" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path) as handle:
+        settings = json.load(handle)
+    if not isinstance(settings, dict):
+        settings = {}
+except (OSError, ValueError):
+    settings = {}
+
+if settings.get("apiKey") != os.environ["OBSIDIAN_API_KEY"]:
+    settings["apiKey"] = os.environ["OBSIDIAN_API_KEY"]
+    with open(path, "w") as handle:
+        json.dump(settings, handle, indent=2)
+    print("docker-entrypoint: set the REST API key from OBSIDIAN_API_KEY")
+PY
+fi
+
+# Re-tighten after the kubelet's fsGroup mount re-added group rw to it (see the umask comment).
+# A one-off manual chmod would be undone by the next mount; doing it on every start is what makes
+# it stick.
+if [[ -e "${DATA_JSON}" ]]; then
+  chmod 0600 "${DATA_JSON}" || log "could not chmod ${DATA_JSON}"
+fi
+
+# ----------------------------------------------------------------------------------------------
+# Virtual display
+#
+# Obsidian is an Electron app; it has no headless mode and will not start without an X display.
+# Xvfb provides one that nothing is attached to. x11vnc is installed in the image but is NOT
+# started here -- an operator attaches it to this same display on demand (see README).
+# ----------------------------------------------------------------------------------------------
+Xvfb "${DISPLAY}" -screen 0 "${GEOMETRY}" -nolisten tcp &
+log "started Xvfb on ${DISPLAY} (${GEOMETRY})"
+
+X_SOCKET="/tmp/.X11-unix/X${DISPLAY#:}"
+for _ in $(seq 1 30); do
+  [[ -S "${X_SOCKET}" ]] && break
+  sleep 1
+done
+[[ -S "${X_SOCKET}" ]] || die "Xvfb did not create ${X_SOCKET}; is /tmp writable?"
+
+# Runs concurrently with Obsidian because it has to: it drives the running renderer over CDP and
+# there is nothing to attach to until Obsidian is up. It polls, so starting it first is safe.
+# tini (PID 1) reaps it once Obsidian is exec'd below and this shell is replaced.
+/usr/local/bin/auto-trust.py &
+
+# --no-sandbox: Chromium's setuid sandbox needs either a setuid helper binary or user namespaces,
+#   neither of which is available to an unprivileged uid in a locked-down pod.
+# --disable-dev-shm-usage: containers get a 64MB /dev/shm by default and Chromium crashes when it
+#   runs out; this makes it use /tmp instead.
+# --disable-gpu: there is no GPU and no DRM device here; without this Electron spends startup
+#   probing for one and falling back anyway.
+# --remote-debugging-port / --remote-allow-origins: the auto-trust mechanism. See auto-trust.py
+#   for why turning Restricted Mode off requires driving the renderer. Chromium binds this port
+#   to 127.0.0.1 only and it is not EXPOSEd, so it is reachable only from inside this container.
+# The vault path is passed as an argument as well as being registered in obsidian.json above --
+# either alone is usually enough, together they make "the vault is open" not depend on which.
+exec /opt/obsidian/obsidian \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --disable-gpu \
+  --remote-debugging-port="${CDP_PORT}" \
+  --remote-allow-origins='*' \
+  "${VAULT_DIR}"

--- a/obsidian/metadata.yaml
+++ b/obsidian/metadata.yaml
@@ -1,0 +1,8 @@
+---
+# renovate: datasource=github-releases depName=obsidianmd/obsidian-releases
+image_version: "1.12.7"
+
+label_title: "obsidian"
+label_description: "Headless Obsidian with the Local REST API plugin baked in and auto-trusted."
+
+build_timeout: 30


### PR DESCRIPTION
Closes #537.

New `obsidian/` image: a headless Obsidian build with `coddingtonbear/obsidian-local-rest-api`
pre-installed and pre-trusted, plus a dormant VNC path for occasional GUI access.

## Shape

- `debian:bookworm-slim` (digest-pinned), multi-stage, **non-root** (uid 1000), `tini` as PID 1.
  No s6-overlay, no init supervisor, no `sudo`.
- Not derived from `linuxserver/obsidian`: its desktop-streaming base ships a GUI with
  passwordless `sudo`, and this container holds the read-write mount of the authoritative vault
  with a deliberately-reachable GUI.
- Obsidian installed from the per-arch **`.tar.gz`** release asset, not the AppImage. An AppImage
  must be executed (`--appimage-extract`) or FUSE-mounted to unpack; the tarball needs neither, so
  the whole download/unpack happens in a `--platform=$BUILDPLATFORM` builder stage and the arm64
  image is assembled without QEMU emulating any of it.
- The Electron system-package set is the resolved `DT_NEEDED` list of the shipped binary, plus
  `xvfb`, `x11vnc` (installed, never started), `python3-websocket`, `libsecret-1-0`, fonts, `tini`.

## Architectures: multi-arch, no exception taken

**`linux/amd64,linux/arm64`.** The `openclaw` amd64-only exception was *not* needed: a cold-cache
multi-arch build finishes in **~12.5 minutes** against a `build_timeout` of 30. Moving the
download/unpack to the build platform is what bought that — the only thing running under emulation
is `apt-get install`.

## Auto-trust

Restricted Mode is not a file: the flag lives in the Electron renderer's `localStorage`, so
copying plugin files in and listing the id in `.obsidian/community-plugins.json` is necessary but
not sufficient. `auto-trust.py` attaches over the Chrome DevTools Protocol to Obsidian's
loopback-only `--remote-debugging-port` and calls `app.plugins.setEnable(true)` — the same runtime
API the GUI's trust toggle calls — then enables the plugin if it isn't already. Idempotent, runs
every start, self-heals a lost `/config`. Technique referenced from `shanehull/obsidian-remote`
(GPL-3.0), implemented independently.

## Obsidian pinned to the stable channel (constrains #538)

`1.12.7`, stable. #538's research found Templater and QuickAdd declare `minAppVersion: 1.13.0`,
satisfiable only on the beta/insider channel. Tracking a pre-release channel in the single
component everything else stands on is not a trade worth making for plugins whose value is to a
human at the GUI; the REST API plugin this image exists to serve declares `minAppVersion: 1.8.7`,
so the critical path has room to spare. The reasoning is recorded in the `Dockerfile` above the
pin, so a future maintainer bumping to beta knows they are re-taking a decision.

Structurally reinforcing: insider builds are not published as GitHub releases in
`obsidianmd/obsidian-releases` at all (verified — every release there is `prerelease=false`, and
1.13.x is absent), so the Renovate datasource cannot drift this onto beta on its own.

One caveat for #538 to settle, not this PR: Templater is not purely GUI-driven. Its folder
templates / "trigger on new file creation" path fires on vault file-creation events, which would
include notes an agent creates through the REST API. If that behaviour is wanted, the stable pin
does block it and the decision is worth re-taking explicitly. QuickAdd is hotkey-driven and has no
such path.

## Health signal

Readiness is the REST API answering on `27124` (HTTPS, plugin-generated self-signed cert), not the
process existing — that listener only binds once the vault is open **and** trusted **and** the
plugin has loaded, so it proves the whole chain.

## GUI access

One image, one process, one writer. `x11vnc` is attached on demand to the display the running
Obsidian process already owns:

```bash
kubectl exec -it deploy/<deployment> -c obsidian -- \
  x11vnc -display :99 -localhost -rfbport 5900 -nopw -shared -forever
kubectl port-forward deploy/<deployment> 5900:5900   # other terminal
```

`-nopw` is safe because of `-localhost`: the port is only reachable from inside the pod netns,
which is exactly what `port-forward` connects to.

## Decisions the issue did not settle

- **Seeding semantics differ from `openclaw`'s `cp -an` for plugin _code_.** `main.js` /
  `manifest.json` / `styles.css` are overwritten unconditionally, because they are build artifacts
  behind a Renovate-tracked pin — copy-if-absent would mean a plugin bump never reached a vault
  that had already started once. The plugin's `data.json` (API key + settings) is never
  overwritten, which is the state `cp -an` exists to protect.
- **`OBSIDIAN_API_KEY` (opt-in).** The plugin otherwise generates a random key discoverable only
  by exec-ing into a running container, which makes wiring the MCP server up declaratively
  awkward. Unset, behaviour is unchanged and the plugin owns its own key.
- **`umask 0027`**, not `077`: group-read lets a sidecar sharing the volume read/commit, while
  group-not-write keeps the single-writer invariant structurally enforced. `data.json` is
  `chmod 0600`'d on every start because an `fsGroup` mount re-loosens it.
- **DevTools port stays open** for the process lifetime (loopback-only, not `EXPOSE`d). Closing it
  would require restarting Obsidian after trust, i.e. a second launch and a supervisor to sequence
  it — against the one-process design.
- **No `scan-obsidian.yaml`.** The issue scoped this to the `test-build` / `publish` pair; happy
  to add the Trivy/Dockle/SBOM workflow `openclaw` carries if wanted.
- **Docker Hub publish left in** (`ppatlabs/obsidian`) via the shared release workflow, alongside
  the private registry. The issue listed private-registry-only as an open question; say the word
  and I'll drop it.

## Verification

`test-build-obsidian` green on `linux/amd64,linux/arm64`; `lint` green; `pre-commit run
--all-files` clean. A successful multi-arch build is this repo's test — note that it does **not**
exercise the runtime path (Xvfb, auto-trust, the REST API binding), which can only be confirmed on
first deploy.
