### PR TITLE
feat(obsidian): bake Tasks and Dataview community plugins

### DIFF
--- a/.github/renovate/image-updates-obsidian.json
+++ b/.github/renovate/image-updates-obsidian.json
@@ -10,7 +10,9 @@
         "custom.regex"
       ],
       "matchPackageNames": [
+        "blacksmithgu/obsidian-dataview",
         "coddingtonbear/obsidian-local-rest-api",
+        "obsidian-tasks-group/obsidian-tasks",
         "obsidianmd/obsidian-releases"
       ],
       "semanticCommitScope": "obsidian"

--- a/obsidian/Dockerfile
+++ b/obsidian/Dockerfile
@@ -64,6 +64,45 @@ RUN mkdir -p /opt/obsidian-seed/plugins/obsidian-local-rest-api && \
     done && \
     grep -q '"id": "obsidian-local-rest-api"' /opt/obsidian-seed/plugins/obsidian-local-rest-api/manifest.json
 
+# The rest of the ratified community plugin set (ppat/images#538): Tasks and Dataview, and
+# nothing else -- Templater, QuickAdd, Linter, Frontmatter Date Manager, Kanban, and any
+# validation plugin were all considered and dropped; see the issue for why each one specifically.
+# Fetched the same way as the REST API plugin above: prebuilt release assets into the seed, not
+# built from source. Whether a given plugin ends up actually turned ON in a vault is decided at
+# runtime, not here -- see docker-entrypoint.sh for why the REST API plugin and these two are
+# seeded identically but enabled differently.
+#
+# minAppVersion checked against this image's pinned stable release (1.12.7) rather than assumed
+# -- this is exactly the check that disqualified Templater and QuickAdd (both declare 1.13.0,
+# today's beta/insider channel only). Tasks' latest release declares minAppVersion 1.8.7, well
+# under 1.12.7.
+# renovate: datasource=github-releases depName=obsidian-tasks-group/obsidian-tasks
+ARG TASKS_VERSION="8.3.0"
+RUN mkdir -p /opt/obsidian-seed/plugins/obsidian-tasks-plugin && \
+    for asset in main.js manifest.json styles.css; do \
+        curl -fsSL -o "/opt/obsidian-seed/plugins/obsidian-tasks-plugin/${asset}" \
+            "https://github.com/obsidian-tasks-group/obsidian-tasks/releases/download/${TASKS_VERSION}/${asset}"; \
+    done && \
+    grep -q '"id": "obsidian-tasks-plugin"' /opt/obsidian-seed/plugins/obsidian-tasks-plugin/manifest.json
+
+# Dataview's latest (and, as of this pin, only recent) release declares minAppVersion 0.13.11,
+# also comfortably under 1.12.7. This is upstream's last release: no commits to `master` since
+# 2025-04-08, so there is nothing newer to weigh -- see #538 ("Bases is primary, Dataview is
+# minimised") for why it's kept anyway (inline task-line queries, which Bases cannot serve at
+# all, being metadata-only) and for the residual that comes with depending on a dormant plugin.
+# Note the manifest.json shipped inside this release still self-reports "version": "0.5.68" even
+# though the release is tagged 0.5.70 -- an upstream packaging slip, confirmed against upstream's
+# own versions.json (which maps 0.5.70 -> minAppVersion 0.13.11). Not a mismatch introduced here;
+# don't "fix" it by re-pinning to 0.5.68, which is an older, different release.
+# renovate: datasource=github-releases depName=blacksmithgu/obsidian-dataview
+ARG DATAVIEW_VERSION="0.5.70"
+RUN mkdir -p /opt/obsidian-seed/plugins/dataview && \
+    for asset in main.js manifest.json styles.css; do \
+        curl -fsSL -o "/opt/obsidian-seed/plugins/dataview/${asset}" \
+            "https://github.com/blacksmithgu/obsidian-dataview/releases/download/${DATAVIEW_VERSION}/${asset}"; \
+    done && \
+    grep -q '"id": "dataview"' /opt/obsidian-seed/plugins/dataview/manifest.json
+
 
 # =======================================================================================================================================
 # Final stage. Debian rather than Alpine because Obsidian is a stock glibc-linked Electron build;

--- a/obsidian/README.md
+++ b/obsidian/README.md
@@ -3,7 +3,10 @@
 A headless [Obsidian](https://obsidian.md/) image: the stock Electron desktop app running against
 a virtual display, with [`obsidian-local-rest-api`](https://github.com/coddingtonbear/obsidian-local-rest-api)
 baked in and turned on automatically, so a vault can be read and written over HTTP by something
-outside the container while exactly one process (this one) ever touches the vault's files.
+outside the container while exactly one process (this one) ever touches the vault's files. The
+ratified community plugin set — [Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)
+and [Dataview](https://github.com/blacksmithgu/obsidian-dataview), and nothing else — is baked in
+alongside it; see "Baked-in community plugins" below.
 
 A VNC server is installed but never started, so an operator can attach to the *same* running
 Obsidian instance on demand for the settings that are only reachable through the GUI.
@@ -36,9 +39,13 @@ enabled on paper and never loads, and the REST API never binds.
 So the entrypoint starts Obsidian with `--remote-debugging-port=9222 --remote-allow-origins=*`
 (Chromium binds that port to `127.0.0.1` only, and it is not `EXPOSE`d), and `auto-trust.py`
 attaches over the Chrome DevTools Protocol and calls the same runtime API the GUI's trust toggle
-calls — `app.plugins.setEnable(true)` — then enables the plugin if it isn't already. It runs on
-every start and is idempotent, which also means it self-heals a container whose `/config` volume
-was lost or replaced. The technique is the one demonstrated by
+calls — `app.plugins.setEnable(true)`, which turns Restricted Mode off *vault-wide* and is what
+lets any plugin already listed in `.obsidian/community-plugins.json` load, Tasks and Dataview
+included. `auto-trust.py` additionally calls `enablePluginAndSave` for the Local REST API plugin
+specifically and then polls its HTTPS listener, because that plugin is the one thing this design
+needs a positive, verified-working guarantee for — it's the only path in from outside the
+container. It runs on every start and is idempotent, which also means it self-heals a container
+whose `/config` volume was lost or replaced. The technique is the one demonstrated by
 [`shanehull/obsidian-remote`](https://github.com/shanehull/obsidian-remote)'s `auto-trust.sh`
 (GPL-3.0; referenced for the approach, implemented independently here).
 
@@ -47,19 +54,56 @@ Obsidian after trust is established, which would mean a second Obsidian launch a
 to sequence it — against the one-process design. It is loopback-only inside a single-purpose
 container, so the only things that can reach it are the other processes this image starts.
 
+## Baked-in community plugins
+
+The ratified set ([`ppat/images#538`](https://github.com/ppat/images/issues/538)) is **Tasks and
+Dataview**, and nothing else:
+
+- **[Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)** (plugin id
+  `obsidian-tasks-plugin`) — inline task tracking: due dates, recurring tasks, done dates,
+  filtering.
+- **[Dataview](https://github.com/blacksmithgu/obsidian-dataview)** (plugin id `dataview`) — kept
+  for one reason: Obsidian's built-in Bases queries cached metadata, not file bodies, so it
+  cannot read inline checkbox task lines at all. Dataview covers exactly that gap and is
+  removable the day Bases can read task lines natively. It's also, deliberately, a read path this
+  image now exposes further than the vault's content model strictly requires: an MCP server
+  sitting in front of this container can serve Dataview query-language (DQL) searches, which is a
+  welcome capability, not an incidental one — nothing is written to the vault by a query, and the
+  "no query engine" requirement in the vault's design is about the vault's *content* staying
+  plain and portable, not a ban on a richer read path. The one real residual: Dataview has had no
+  commits to `master` since 2025-04-08, so a read path that leans on it leans on a dormant
+  plugin — a cost already accepted, since Dataview is retained regardless for inline task queries
+  that Bases structurally cannot serve.
+
+**Deliberately excluded** (`ppat/images#538`, `ppat/obsidian-vault#2`): Templater and QuickAdd
+(both require Obsidian `>= 1.13.0`, today's beta/insider channel only — this image pins stable
+`1.12.7`), Linter and Frontmatter Date Manager (frontmatter normalisation is owned entirely by
+the maintenance pass that runs outside the application), a validation plugin such as Propsec (a
+second, lossy source of truth competing with the JSON-Schema validator that is the authoritative
+gate), and Kanban (publicly seeking maintainers, unmaintained; board views come from Bases
+instead). Don't install any of these by hand — that recreates exactly the conflict the ratified
+set exists to avoid.
+
 ## What the entrypoint does
 
 `docker-entrypoint.sh` runs under `tini` as PID 1 (no s6-overlay, no init supervisor, no `sudo`)
 and, as uid 1000:
 
-- **Installs the plugin into the vault.** `/vault` and `/config` are external volumes at runtime,
-  so anything baked into those paths would be shadowed by the mount; everything baked in lives
-  under `/opt/obsidian-seed` and is applied at start. `main.js`/`manifest.json`/`styles.css` are
-  overwritten unconditionally — plugin code tracks the image, and copy-if-absent would mean a
-  Renovate version bump never reached a vault that had already been started once. The plugin's
-  own `data.json` (API key and settings) is never overwritten.
-- **Merges** the plugin id into `.obsidian/community-plugins.json`, preserving any other plugins
-  an operator enabled through the GUI.
+- **Force-copies every baked-in plugin's code into the vault, on every start, no exceptions.**
+  `/vault` and `/config` are external volumes at runtime, so anything baked into those paths
+  would be shadowed by the mount; everything baked in lives under `/opt/obsidian-seed` and is
+  applied at start. `main.js`/`manifest.json`/`styles.css` are overwritten unconditionally —
+  plugin code tracks the image, and copy-if-absent would mean a Renovate version bump never
+  reached a vault that had already been started once. A plugin's own state, such as the REST API
+  plugin's `data.json` (API key and settings), is never in this list and is never overwritten.
+- **Enables plugins differently depending on which one it is.** The Local REST API plugin is
+  merged into `.obsidian/community-plugins.json` on *every* start — it's load-bearing, nothing
+  outside the container can reach the vault without it, so its enabled state must never be
+  allowed to drift. Tasks and Dataview are merged in only the *first* time their plugin directory
+  is seeded (i.e. it did not already exist before this start); after that, an operator who
+  disables one of them at the GUI has that choice respected on every later restart instead of the
+  container silently re-enabling it out from under them. Code and enablement are deliberately
+  decoupled for exactly this reason — see `seed_plugin()` in `docker-entrypoint.sh`.
 - **Registers the vault** in `${XDG_CONFIG_HOME}/obsidian/obsidian.json` if that file is absent,
   with a vault id derived from the vault path so it is stable if `/config` is lost. This does not
   establish trust; it only makes Obsidian open the vault instead of the vault picker.

--- a/obsidian/docker-entrypoint.sh
+++ b/obsidian/docker-entrypoint.sh
@@ -13,12 +13,13 @@ umask 0027
 
 VAULT_DIR="${OBSIDIAN_VAULT_DIR:-/vault}"
 CONFIG_DIR="${XDG_CONFIG_HOME:-/config}"
-PLUGIN_ID="${OBSIDIAN_PLUGIN_ID:-obsidian-local-rest-api}"
+REST_API_PLUGIN_ID="${OBSIDIAN_PLUGIN_ID:-obsidian-local-rest-api}"
 GEOMETRY="${OBSIDIAN_SCREEN_GEOMETRY:-1920x1080x24}"
 CDP_PORT="${OBSIDIAN_CDP_PORT:-9222}"
 
-SEED_PLUGIN_DIR="/opt/obsidian-seed/plugins/${PLUGIN_ID}"
-VAULT_PLUGIN_DIR="${VAULT_DIR}/.obsidian/plugins/${PLUGIN_ID}"
+SEED_PLUGINS_DIR="/opt/obsidian-seed/plugins"
+VAULT_PLUGINS_DIR="${VAULT_DIR}/.obsidian/plugins"
+REST_API_VAULT_PLUGIN_DIR="${VAULT_PLUGINS_DIR}/${REST_API_PLUGIN_ID}"
 ELECTRON_CONFIG_DIR="${CONFIG_DIR}/obsidian"
 
 log() {
@@ -37,27 +38,13 @@ die() {
 # image put there, so nothing plugin-related can simply be baked into its final location -- the
 # mount would shadow it. Everything baked in lives under /opt/obsidian-seed and is applied here.
 # ----------------------------------------------------------------------------------------------
-mkdir -p "${VAULT_PLUGIN_DIR}" "${ELECTRON_CONFIG_DIR}" \
+mkdir -p "${VAULT_PLUGINS_DIR}" "${ELECTRON_CONFIG_DIR}" \
   || die "cannot write to ${VAULT_DIR} / ${CONFIG_DIR}; both must be writable by uid $(id -u)"
-
-# Plugin code tracks the IMAGE, not the volume, so this overwrites unconditionally. This is a
-# deliberate departure from the copy-if-absent seeding the openclaw image uses: main.js/
-# manifest.json/styles.css are build artifacts pinned by a Renovate-tracked version in the
-# Dockerfile, and copy-if-absent would mean a plugin version bump never actually reached any
-# vault that had already been started once. The plugin's own state -- data.json, which holds the
-# generated API key and settings -- is NOT in this list and is never overwritten.
-install -m 0640 \
-  "${SEED_PLUGIN_DIR}/main.js" \
-  "${SEED_PLUGIN_DIR}/manifest.json" \
-  "${SEED_PLUGIN_DIR}/styles.css" \
-  "${VAULT_PLUGIN_DIR}/" \
-  || die "failed to install the ${PLUGIN_ID} plugin into ${VAULT_PLUGIN_DIR}"
-log "installed ${PLUGIN_ID} $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' \
-  "${VAULT_PLUGIN_DIR}/manifest.json") into ${VAULT_PLUGIN_DIR}"
 
 # Obsidian reads the set of enabled community plugins from this file. Merge rather than write:
 # an operator may have enabled other plugins through the GUI and we must not drop them.
-python3 - "${VAULT_DIR}/.obsidian/community-plugins.json" "${PLUGIN_ID}" <<'PY'
+enable_plugin() {
+  python3 - "${VAULT_DIR}/.obsidian/community-plugins.json" "$1" <<'PY'
 import json
 import os
 import sys
@@ -77,6 +64,65 @@ if plugin_id not in plugins:
         json.dump(plugins, handle, indent=2)
     print("docker-entrypoint: added %s to %s" % (plugin_id, os.path.basename(path)))
 PY
+}
+
+# seed_plugin <plugin_id> <always|first-seed>
+#
+# Plugin CODE is force-copied on every start no matter which mode is passed -- no exceptions.
+# This is a deliberate departure from the copy-if-absent seeding the openclaw image uses:
+# main.js/manifest.json/styles.css are build artifacts pinned by a Renovate-tracked version in
+# the Dockerfile, and copy-if-absent would mean a plugin version bump never actually reached any
+# vault that had already been started once. A plugin's own state -- data.json, where the REST API
+# plugin keeps its generated key and settings -- is never in this list and is never overwritten.
+#
+# Plugin ENABLEMENT (whether its id is added to .obsidian/community-plugins.json) is where the
+# mode argument matters, and is the one place the three baked-in plugins deliberately diverge:
+#   - "always": added to the enabled list on every start, unconditionally. Reserved for
+#     obsidian-local-rest-api, which is load-bearing -- without it nothing outside this container
+#     can touch the vault at all, so its enabled state must never be allowed to drift.
+#   - "first-seed": added to the enabled list only the first time this plugin's directory is
+#     seeded, i.e. only when the directory did not already exist before this start. Used for
+#     obsidian-tasks-plugin and dataview. After the first boot, an operator who deliberately
+#     disables one of these at the GUI has that choice respected on every later restart --
+#     re-enabling it out from under them would be the container fighting a deliberate human
+#     decision, which is exactly the behaviour "always" mode must NOT generalize to.
+seed_plugin() {
+  local plugin_id="$1" enable_mode="$2"
+  local seed_dir="${SEED_PLUGINS_DIR}/${plugin_id}"
+  local vault_dir="${VAULT_PLUGINS_DIR}/${plugin_id}"
+  local is_first_seed="false"
+  [[ -d "${vault_dir}" ]] || is_first_seed="true"
+
+  mkdir -p "${vault_dir}" || die "cannot write to ${vault_dir}"
+  install -m 0640 \
+    "${seed_dir}/main.js" \
+    "${seed_dir}/manifest.json" \
+    "${seed_dir}/styles.css" \
+    "${vault_dir}/" \
+    || die "failed to install the ${plugin_id} plugin into ${vault_dir}"
+  log "installed ${plugin_id} $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' \
+    "${vault_dir}/manifest.json") into ${vault_dir}"
+
+  case "${enable_mode}" in
+    always)
+      enable_plugin "${plugin_id}"
+      ;;
+    first-seed)
+      if [[ "${is_first_seed}" == "true" ]]; then
+        enable_plugin "${plugin_id}"
+      else
+        log "leaving ${plugin_id} enablement as-is: already seeded from a previous start"
+      fi
+      ;;
+    *)
+      die "seed_plugin: unknown enable_mode ${enable_mode}"
+      ;;
+  esac
+}
+
+seed_plugin "${REST_API_PLUGIN_ID}" always
+seed_plugin obsidian-tasks-plugin first-seed
+seed_plugin dataview first-seed
 
 # obsidian.json is Electron-side (not vault-side) state listing the vaults Obsidian knows about.
 # Written only when absent, so anything an operator does in the GUI afterwards wins. The vault id
@@ -96,7 +142,7 @@ fi
 # declaratively. Setting OBSIDIAN_API_KEY (e.g. from a Kubernetes Secret) pins it instead. Opt-in:
 # unset, the plugin keeps generating and owning its own key. Merged into any existing data.json so
 # settings an operator changed in the GUI survive.
-DATA_JSON="${VAULT_PLUGIN_DIR}/data.json"
+DATA_JSON="${REST_API_VAULT_PLUGIN_DIR}/data.json"
 if [[ -n "${OBSIDIAN_API_KEY}" ]]; then
   python3 - "${DATA_JSON}" <<'PY'
 import json

--- a/obsidian/metadata.yaml
+++ b/obsidian/metadata.yaml
@@ -3,6 +3,6 @@
 image_version: "1.12.7"
 
 label_title: "obsidian"
-label_description: "Headless Obsidian with the Local REST API plugin baked in and auto-trusted."
+label_description: "Headless Obsidian with the Local REST API plugin, Tasks, and Dataview baked in and auto-trusted."
 
 build_timeout: 30


### PR DESCRIPTION
## Summary

- Bakes the rest of the ratified community plugin set (#538) into the image: Tasks and Dataview, fetched as prebuilt release assets the same way `obsidian-local-rest-api` already is.
- `minAppVersion` verified for each against this image's pinned stable Obsidian (1.12.7), not assumed: Tasks 8.3.0 declares 1.8.7; Dataview 0.5.70 declares 0.13.11. Both comfortably clear the bar that disqualified Templater/QuickAdd (1.13.0, beta-only).
- Plugin **code** is force-copied on every start for all three plugins, unchanged from the existing REST API pattern (Renovate-pinned build artifacts; copy-if-absent would strand a version bump on an already-booted vault).
- Plugin **enablement** now differs by kind: `obsidian-local-rest-api` stays ensured-enabled on every start (load-bearing -- it's the only path in from outside the container). `obsidian-tasks-plugin` and `dataview` are only added to `.obsidian/community-plugins.json` the first time their plugin directory is seeded (i.e. the directory didn't exist before this start), so an operator who disables one at the GUI has that choice respected on later restarts instead of the container fighting it.
- `obsidian/README.md` documents the baked-in set, the deliberately excluded set (Templater, QuickAdd, Linter, Frontmatter Date Manager, a validation plugin, Kanban) and why, and the force-copy/conditional-enable split.
- `.github/renovate/image-updates-obsidian.json` extended to track the two new upstream deps for labeling/commit-scope.
- `obsidian/metadata.yaml`: `image_version` left at `1.12.7` deliberately -- per the `openclaw` plugin-hardening precedent (#532), that field is Renovate-locked 1:1 to the pinned upstream binary version via the regex custom manager, and this change doesn't move it. `label_description` updated instead to mention the new plugins.

Depends on #537 (closed, already on `main`). Implements #538.

## Test plan

- [x] `pre-commit run --all-files` (scoped to changed files) -- yamllint, markdownlint, shellcheck, hadolint all pass
- [x] `bash -n` on the entrypoint script
- [ ] `test-build-obsidian` CI green on both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)