### PR TITLE
fix(obsidian): bind the REST API listener to all interfaces, not loopback

### DIFF
--- a/obsidian/README.md
+++ b/obsidian/README.md
@@ -110,6 +110,11 @@ and, as uid 1000:
 - **Pins the REST API key** from `OBSIDIAN_API_KEY` if that variable is set (see below), then
   `chmod 0600`s `data.json` on every start — a Kubernetes `fsGroup` mount re-adds group `rw` to
   every existing file before the container starts, so a one-off `chmod` would not survive.
+- **Binds the REST API listeners to all interfaces** (`bindingHost: "0.0.0.0"` in `data.json`,
+  merged in the same way as the API key) instead of the plugin's own default of `127.0.0.1`.
+  Loopback-only is right for the desktop use case the plugin was built for, but wrong for a
+  container whose only purpose is to be reached from outside itself — see "Health" below for why
+  this is load-bearing, not just a convenience.
 - **Starts `Xvfb`** on `$DISPLAY` and waits for its socket.
 - **Starts `auto-trust.py`** in the background (it polls, so starting it before Obsidian is fine).
 - **`exec`s Obsidian**, which becomes the container's long-running process.
@@ -154,6 +159,17 @@ readinessProbe:
 The plaintext listener on `27123` is left disabled — the plugin defaults it off and nothing here
 needs it.
 
+This only works because the entrypoint forces the plugin's `bindingHost` to `0.0.0.0` (see above):
+`kubelet` connects to the pod IP, never to loopback, so a `startupProbe`/`readinessProbe`/
+`livenessProbe` against `27124` on a loopback-bound listener fails every attempt — the startup
+probe exhausts its budget and liveness then restarts the container in a loop, never reaching
+`Running`. The same bind is what lets anything else reach the plugin over the pod network at all,
+including MCP server pods proxying this API from a different node. Binding wider than loopback is
+not the security boundary for this API and was never meant to be one: that boundary is the
+`Service` being `ClusterIP` with no ingress, a `NetworkPolicy` admitting only the intended peers,
+and the plugin still requiring its bearer token on every request regardless of which interface the
+request arrived on.
+
 ## GUI access
 
 The GUI is for the handful of settings that are only reachable through it — property types,
@@ -183,6 +199,31 @@ would break the single-writer invariant.
 
 4. When finished, stop `x11vnc` with `Ctrl-C` in the `kubectl exec` terminal. Obsidian keeps
    running; only the viewer goes away.
+
+## Expected startup log noise
+
+Three lines show up on every boot that look like failures and are not — the boot chain completes
+past all of them, so treat any of the three, alone, as expected rather than as something to chase:
+
+- `_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root` — `Xvfb` wants that directory
+  root-owned; this container runs as uid 1000 with `/tmp` as an `emptyDir`. Warning only, the X11
+  socket is still created (the entrypoint waits on it and would `die` if it were not).
+- `Failed to connect to the bus: ... /run/dbus/system_bus_socket` — Electron/Chromium probing the
+  system D-Bus for desktop integration (notifications, power/screensaver inhibition, and the
+  Secret Service keyring API). There is no D-Bus daemon in this image and none is needed for a
+  headless vault.
+- `LaunchProcess: failed to execvp: xdg-settings` — Chromium checking default-browser association,
+  which is meaningless for this container.
+
+Related to the D-Bus line: this image installs `libsecret-1-0` (Chromium's Secret Service /
+GNOME-keyring backend for its `safeStorage` API), but it is `dlopen()`ed by soname at runtime, not
+a link-time dependency — confirmed by inspecting the shipped Electron binary: `readelf -d obsidian`
+lists no `libsecret` `NEEDED` entry, while `strings obsidian` contains
+`key_storage_libsecret.cc`, `chrome_libsecret_os_crypt_password_v2`, and the literal fallback
+message `Could not load libsecret-1.so.0:`. With no D-Bus daemon here, that dlopen always fails and
+the keyring backend silently degrades — harmless today, since Obsidian Sync is unused and the REST
+API key arrives via `OBSIDIAN_API_KEY`/`data.json` rather than the OS keyring, but it is the first
+place a future plugin that wants OS-level credential storage would fail silently.
 
 ## Architectures
 

--- a/obsidian/docker-entrypoint.sh
+++ b/obsidian/docker-entrypoint.sh
@@ -166,6 +166,46 @@ if settings.get("apiKey") != os.environ["OBSIDIAN_API_KEY"]:
 PY
 fi
 
+# The plugin binds its listeners to 127.0.0.1 by default (settings key "bindingHost", read by
+# both the HTTPS and the disabled-here HTTP listener's `.listen()` call; default unset, which
+# falls back to the constant DefaultBindingHost = "127.0.0.1" -- confirmed against the plugin's
+# own src/main.ts and src/constants.ts at release 5.0.2, the version baked into this image). That
+# default is right for a desktop app talking to itself; it is wrong here. This container's only
+# reason to exist is to be reached from outside itself -- the MCP server pods that proxy the REST
+# API run on a *different node* -- and the kubelet's probes also connect to the pod IP, never to
+# loopback. Loopback-only means the startup/readiness/liveness probes can never succeed (the
+# kubelet is not "inside" this container) and the MCP servers can never reach the API at all, so
+# this isn't a hardening setting worth preserving -- it just breaks the one thing this image
+# exists to serve.
+#
+# Setting it to 0.0.0.0 is not the security boundary and was never meant to be one: the actual
+# boundary is the Service being ClusterIP with no ingress, a NetworkPolicy admitting only the MCP
+# server pods, and the plugin still requiring its bearer token (OBSIDIAN_API_KEY, above) on every
+# request. Binding wider than loopback does not weaken any of those.
+#
+# Merged into the same data.json as the API key, for the same reason: don't clobber whatever else
+# is in there (the API key just set above, or settings an operator changed in the GUI).
+REST_API_BINDING_HOST="0.0.0.0"
+python3 - "${DATA_JSON}" "${REST_API_BINDING_HOST}" <<'PY'
+import json
+import sys
+
+path, binding_host = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as handle:
+        settings = json.load(handle)
+    if not isinstance(settings, dict):
+        settings = {}
+except (OSError, ValueError):
+    settings = {}
+
+if settings.get("bindingHost") != binding_host:
+    settings["bindingHost"] = binding_host
+    with open(path, "w") as handle:
+        json.dump(settings, handle, indent=2)
+    print("docker-entrypoint: set bindingHost to %s so the REST API is reachable off-host" % binding_host)
+PY
+
 # Re-tighten after the kubelet's fsGroup mount re-added group rw to it (see the umask comment).
 # A one-off manual chmod would be undone by the next mount; doing it on every start is what makes
 # it stick.


### PR DESCRIPTION
## Problem

`ppat/obsidian` (`1.12.7`) ran on the real cluster for the first time and never reaches `Running`. The boot chain works end to end — Xvfb, Electron, CDP-driven auto-trust, all three plugins enabled and loaded, REST API answering `HTTP 200` on `https://127.0.0.1:27124/` — but the plugin binds **loopback only**, and:

- The pod's `startupProbe`/`readinessProbe`/`livenessProbe` are all `httpGet` against port `27124`, and `kubelet` connects to the **pod IP**, never to loopback. Every probe attempt fails, the startup probe exhausts its budget, and liveness restart-loops the container.
- Two MCP server pods on a **different node** proxy this REST API and can never reach it either. They report `1/1 Ready` only because their own health check doesn't require Obsidian (they connect lazily) — so the whole platform silently does nothing until this is fixed.

## Root cause and fix

`coddingtonbear/obsidian-local-rest-api` at `5.0.2` (the version baked into this image) has a `bindingHost` setting, default unset → falls back to `DefaultBindingHost = "127.0.0.1"` (`src/constants.ts`). It's consulted by **both** the HTTPS (`27124`) and the (disabled here) HTTP (`27123`) listener's `.listen()` call (`src/main.ts`) — confirmed by reading the plugin's own source at the pinned tag, not assumed.

`docker-entrypoint.sh` now merges `bindingHost: "0.0.0.0"` into the plugin's `data.json`, in the same idempotent, non-clobbering style as the existing `OBSIDIAN_API_KEY` seeding right above it (load → merge one key → write only if changed).

This reads as a security loosening, so it's worth being explicit: the bind address was never the security boundary. That boundary is the `Service` being `ClusterIP` with no ingress, a `NetworkPolicy` admitting only the MCP server pods, and the plugin still requiring its bearer token on every request regardless of which interface the request arrived on. Both the entrypoint comment and the README explain this.

## Also included (documentation only, no behavior change)

Three log lines that show up on every boot and look alarming but aren't — documented in the README's new "Expected startup log noise" section so a future debugging session doesn't waste time on them:

- `_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root` (Xvfb, non-root container, harmless)
- `Failed to connect to the bus: ... /run/dbus/system_bus_socket` (Chromium probing for a D-Bus daemon that doesn't exist here)
- `LaunchProcess: failed to execvp: xdg-settings` (Chromium's default-browser check)

Also verified, since it was asked: whether `libsecret-1-0` is a real link-time dependency of the shipped Obsidian binary. Downloaded the same `obsidian-1.12.7.tar.gz` this image's Dockerfile fetches and inspected the ELF: `readelf -d obsidian` has **no `libsecret` `NEEDED` entry**, while `strings obsidian` contains `key_storage_libsecret.cc`, `chrome_libsecret_os_crypt_password_v2`, and the literal string `Could not load libsecret-1.so.0:`. So it's `dlopen()`ed at runtime by Chromium's os_crypt backend, exactly as the Dockerfile's existing per-package comment already said — confirmed rather than assumed. Recorded in the README; with no D-Bus daemon in this image the dlopen always fails and the keyring backend silently degrades, which doesn't matter today (no Obsidian Sync, API key arrives via env var) but is where a future credential-storage-using plugin would fail quietly.

## Verification

- `pre-commit run --all-files` passes locally.
- CI (`test-build-obsidian`, multi-arch amd64+arm64) proves the image still **builds**. It does **not** prove the fix works — that needs another real cluster deploy to confirm the probes go green and the MCP server pods can actually reach `27124` across nodes. Flagging this explicitly rather than implying CI verified runtime behavior.
- The published tag is mutable and reused across rebuilds, so once this merges and republishes, the image digest moves and `homelab-ops-kubernetes-apps`' pin (tag + digest) needs updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)