### PR TITLE
fix(openclaw): drop diffs, assert plugin install integrity at build time

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -8,36 +8,52 @@ FROM --platform=$TARGETPLATFORM ghcr.io/openclaw/openclaw:2026.7.1-slim@sha256:6
 # exists, removes that runtime dependency. They're baked in so they're *available*; each stays
 # dormant unless the deployment's config allowlists it (a non-empty `plugins.allow` is a hard
 # gate -- an installed-or-bundled plugin absent from it never loads).
-#   whatsapp                - WhatsApp/Baileys channel
-#   diagnostics-prometheus  - Prometheus metrics exporter
-#   memory-lancedb          - LanceDB-backed memory store
-#   lobster                 - action-approval gating
 #   brave-plugin            - Brave Search web-search provider (needs BRAVE_API_KEY)
+#   diagnostics-prometheus  - Prometheus metrics exporter
+#   lobster                 - action-approval gating
+#   memory-lancedb          - LanceDB-backed memory store
 #   searxng-plugin          - self-hosted SearXNG web-search provider (no third-party API key;
 #                             unlike key-free providers it can win provider auto-detection)
-#   diffs                   - read-only diff viewer / file renderer for agents
 #   voice-call              - Twilio/Telnyx/Plivo outbound calling. Baked in but NOT wired yet:
 #                             notify-mode outbound needs no public webhook (the initial <Say>
 #                             TwiML ships inside the create-call request), so it suits this
 #                             ingress-free gateway -- but the plugin exposes no destination
 #                             allowlist, so a deployment enabling it must pin `toNumber` and
 #                             keep the `voice_call` tool denied to the agent.
+#   whatsapp                - WhatsApp/Baileys channel
 # NOT installed here, deliberately: duckduckgo, document-extract, web-readability and xai are
 # ALREADY bundled in the base image under /app/dist/extensions. They need allowlisting in the
-# deployment config, not an install -- don't add redundant install lines for them.
+# deployment config, not an install -- don't add redundant install lines for them. (xai in
+# particular cannot be "removed" from this image without deleting an upstream extension
+# directory; it is inert while the deployment leaves it out of `plugins.allow`.)
 # Pin exact plugin versions for reproducibility/supply-chain. `npm:<scoped>@<version>` is the
 # doc-confirmed form for scoped packages with an explicit version; `--pin` records the resolved
 # exact version, and `--force` confirms the non-ClawHub (npm) source non-interactively during
 # the build. Pinned to 2026.7.1 to match the base image + the deployed app version. (These are
 # the same @openclaw/* artifacts ClawHub serves -- ClawHub installs fall back to npm anyway.)
-RUN openclaw plugins install npm:@openclaw/whatsapp@2026.7.1 --pin --force && \
+# Do NOT switch these to `clawhub:` to chase supply-chain metadata: the npm source already
+# records an integrity hash. The `plugins.installs_missing_integrity` finding from
+# `openclaw status --deep` is not caused by the install source -- see the assertion below and
+# the README for what actually drops those hashes.
+RUN openclaw plugins install npm:@openclaw/brave-plugin@2026.7.1 --pin --force && \
     openclaw plugins install npm:@openclaw/diagnostics-prometheus@2026.7.1 --pin --force && \
-    openclaw plugins install npm:@openclaw/memory-lancedb@2026.7.1 --pin --force && \
     openclaw plugins install npm:@openclaw/lobster@2026.7.1 --pin --force && \
-    openclaw plugins install npm:@openclaw/brave-plugin@2026.7.1 --pin --force && \
+    openclaw plugins install npm:@openclaw/memory-lancedb@2026.7.1 --pin --force && \
     openclaw plugins install npm:@openclaw/searxng-plugin@2026.7.1 --pin --force && \
-    openclaw plugins install npm:@openclaw/diffs@2026.7.1 --pin --force && \
-    openclaw plugins install npm:@openclaw/voice-call@2026.7.1 --pin --force
+    openclaw plugins install npm:@openclaw/voice-call@2026.7.1 --pin --force && \
+    openclaw plugins install npm:@openclaw/whatsapp@2026.7.1 --pin --force
+
+# Assert every install record above carries an integrity hash, so a regression in what the build
+# records is caught here rather than surfacing later as the warn-level `status --deep` finding
+# `plugins.installs_missing_integrity`. Nothing backfills integrity onto an existing record --
+# the only documented remedy is reinstalling, which a deployed gateway cannot do (read-only
+# rootfs, no registry egress, OPENCLAW_OFFLINE=1) -- so build time is the only place it can be
+# guaranteed. This also pins down what the npm source actually records, which is the evidence
+# the missing-integrity investigation needs.
+COPY --chmod=644 assert-plugin-integrity.mjs /tmp/assert-plugin-integrity.mjs
+RUN openclaw plugins inspect --all --json > /tmp/plugins.json \
+    && node /tmp/assert-plugin-integrity.mjs /tmp/plugins.json \
+    && rm -f /tmp/plugins.json /tmp/assert-plugin-integrity.mjs
 
 # npm-source installs land plugin package state (npm/projects/*) and the pinned install records
 # under $OPENCLAW_DATA_DIR (defaults to /home/node/.openclaw) -- exactly the path a deployment

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,19 +1,18 @@
 # openclaw
 
 An [OpenClaw](https://docs.openclaw.ai/) gateway image, built on top of the official
-[`ghcr.io/openclaw/openclaw`](https://github.com/openclaw/openclaw) `-slim` tag, with eight
+[`ghcr.io/openclaw/openclaw`](https://github.com/openclaw/openclaw) `-slim` tag, with seven
 plugins installed at build time:
 
 | Plugin | Purpose |
 | --- | --- |
-| `@openclaw/whatsapp` | WhatsApp/Baileys channel |
-| `@openclaw/diagnostics-prometheus` | Prometheus metrics exporter |
-| `@openclaw/memory-lancedb` | LanceDB-backed long-term memory store |
-| `@openclaw/lobster` | Action-approval gating |
 | `@openclaw/brave-plugin` | Brave Search web-search provider (needs `BRAVE_API_KEY`) |
+| `@openclaw/diagnostics-prometheus` | Prometheus metrics exporter |
+| `@openclaw/lobster` | Action-approval gating |
+| `@openclaw/memory-lancedb` | LanceDB-backed long-term memory store |
 | `@openclaw/searxng-plugin` | Self-hosted SearXNG web-search provider (no third-party key) |
-| `@openclaw/diffs` | Read-only diff viewer / file renderer for agents |
 | `@openclaw/voice-call` | Twilio/Telnyx/Plivo calling (available, not wired -- see below) |
+| `@openclaw/whatsapp` | WhatsApp/Baileys channel |
 
 No official OpenClaw tag bundles these plugins -- they're external ClawHub/npm packages
 that OpenClaw otherwise installs itself the first time a gateway references them, which
@@ -27,7 +26,41 @@ everything else is available but inert until a deployment's config allowlists it
 
 `duckduckgo`, `document-extract`, `web-readability` and `xai` are already bundled in the base
 image under `/app/dist/extensions`. They need allowlisting in the deployment config, not an
-install -- don't add redundant install lines for them.
+install -- don't add redundant install lines for them. `xai` in particular cannot be *removed*
+from this image without deleting an upstream extension directory; it stays inert as long as the
+deployment leaves it out of `plugins.allow`.
+
+`@openclaw/diffs` was dropped: its useful mode (rendering a diff to PNG/PDF) needs Chromium,
+which the `-slim` base image strips along with Puppeteer.
+
+## Install integrity
+
+`assert-plugin-integrity.mjs` runs as a build step and **fails the build** if any plugin install
+record lacks an `integrity` hash. It also fails if it finds no install records at all, so a change
+to `openclaw plugins inspect --all --json` can't silently turn the check into a no-op.
+
+Nothing backfills integrity onto an existing record -- the only documented remedy is reinstalling,
+which a deployed gateway cannot do (read-only rootfs, no registry egress, `OPENCLAW_OFFLINE=1`).
+Build time is the only place it can be guaranteed, hence the gate.
+
+### Why `openclaw status --deep` can still report missing integrity
+
+`plugins.installs_missing_integrity` on a running gateway is **not** caused by the install source.
+The npm source records an integrity hash, which is why the plugins installed into the first
+version of this image (`whatsapp`, `diagnostics-prometheus`) do not appear in that finding while
+every plugin added later does.
+
+The cause is that the install index lives in the gateway *state* directory
+(`state/openclaw.sqlite`), which a deployment typically mounts a PVC over, and
+`docker-entrypoint.sh` restores the build-time seed with `cp -an` (copy-if-absent). On a PVC's
+very first boot the seed's index is copied out intact, hashes and all. After that the file
+exists, so every later image -- including the newer install records it baked -- is skipped.
+Plugin *directories* still get copied, so the gateway rediscovers those plugins and writes fresh
+index rows with no integrity.
+
+So the hashes are correct in the image and lost on the way into an already-initialised state
+directory. Removing `state/openclaw.sqlite` lets the gateway reseed it from the image on next
+start -- **back up the state directory first**, that DB holds more than the plugin index.
 
 ## `voice-call` caveats
 

--- a/openclaw/assert-plugin-integrity.mjs
+++ b/openclaw/assert-plugin-integrity.mjs
@@ -1,0 +1,92 @@
+// Build-time gate: every registry-sourced plugin install must carry an integrity hash.
+// Invoked as `node assert-plugin-integrity.mjs <json>` from the Dockerfile -- no shebang, so it
+// does not need the executable bit (see the check-shebang-scripts-are-executable pre-commit hook).
+//
+// `openclaw status --deep` reports missing hashes as the warn-level finding
+// `plugins.installs_missing_integrity`, and there is no command that backfills integrity onto an
+// existing record -- the only documented remedy is reinstalling. The gateway runs with a
+// read-only rootfs, no registry egress and OPENCLAW_OFFLINE=1, so reinstalling is impossible
+// there. Build time is the only place this is fixable, so a miss fails the build rather than
+// shipping an image whose supply-chain evidence is silently incomplete.
+//
+// Deliberately self-diagnosing: `openclaw plugins inspect --all --json` has no schema contract we
+// control, so rather than assume a shape this walks the whole document for records that look like
+// registry installs. Finding NO such records is treated as a failure too -- a shape change that
+// silently matched nothing would otherwise turn this gate into a no-op that always passes.
+import { readFileSync } from "node:fs";
+
+const REGISTRY_SOURCES = new Set(["npm", "clawhub", "npm-pack", "marketplace"]);
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error("usage: assert-plugin-integrity.mjs <plugins-inspect-json>");
+  process.exit(2);
+}
+
+let doc;
+try {
+  doc = JSON.parse(readFileSync(inputPath, "utf8"));
+} catch (error) {
+  console.error(`ERROR: could not parse plugin inspect JSON: ${error.message}`);
+  process.exit(2);
+}
+
+// Any object carrying a registry `source` is treated as an install record, wherever it sits in
+// the document (top level, nested under `install`, inside a `plugins`/`items` array, ...).
+const records = [];
+const seen = new Set();
+const walk = (node, idHint) => {
+  if (!node || typeof node !== "object" || seen.has(node)) {
+    return;
+  }
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      walk(entry, idHint);
+    }
+    return;
+  }
+  const id = node.id ?? node.pluginId ?? node.name ?? idHint;
+  if (typeof node.source === "string" && REGISTRY_SOURCES.has(node.source)) {
+    records.push({ id: id ?? "<unknown>", source: node.source, integrity: node.integrity });
+  }
+  for (const value of Object.values(node)) {
+    walk(value, id);
+  }
+};
+walk(doc, undefined);
+
+if (records.length === 0) {
+  console.error(
+    "ERROR: found no registry-sourced plugin install records in `openclaw plugins inspect --all --json`.",
+  );
+  console.error(
+    "The output shape likely changed, which would make this check silently vacuous. Inspect it and update this script.",
+  );
+  console.error(`Top-level keys: ${Object.keys(doc ?? {}).join(", ") || "(none)"}`);
+  process.exit(1);
+}
+
+const missing = records.filter(
+  (record) => !(typeof record.integrity === "string" && record.integrity.trim() !== ""),
+);
+
+if (missing.length > 0) {
+  console.error("ERROR: plugin installs were recorded without an integrity hash:");
+  for (const record of missing) {
+    console.error(`  - ${record.id} (source: ${record.source})`);
+  }
+  console.error(
+    "\nThese surface as `plugins.installs_missing_integrity` in `openclaw status --deep`,",
+  );
+  console.error(
+    "and cannot be repaired at runtime (read-only rootfs, no registry egress, OPENCLAW_OFFLINE=1).",
+  );
+  console.error("Check the install source prefix in the Dockerfile (clawhub: vs npm:).");
+  process.exit(1);
+}
+
+console.log(`OK: ${records.length} plugin install record(s), all carrying an integrity hash:`);
+for (const record of records) {
+  console.log(`  - ${record.id} (${record.source})`);
+}


### PR DESCRIPTION
## The install source was never the problem

`whatsapp` and `diagnostics-prometheus` are installed with `npm:` and are **absent** from the missing-integrity warning, while every plugin added later appears in it:

```
Plugin index records missing integrity: - brave - diffs - lobster - memory-lancedb - searxng - voice-call
```

npm-source installs record an integrity hash. The install source stays `npm:` — the doc-confirmed exact-version pin form chosen in 746541ae for reproducibility. A Dockerfile comment now warns against "fixing" this finding by switching to `clawhub:`.

## What actually drops the hashes

The install index lives in the gateway **state** dir (`state/openclaw.sqlite`), which the deployment mounts a PVC over, and `docker-entrypoint.sh` restores the build-time seed with `cp -an` (copy-if-absent).

- A PVC's **first** boot copies the seed index out intact, hashes and all — that's why the two original plugins are fine.
- After that the file exists, so `cp -an` skips it, and every later image's install records are never applied.
- Plugin **directories** still get copied, so the gateway rediscovers those plugins and writes fresh index rows with **no integrity**.

So the hashes are correct in the image and lost on the way into an already-initialised state dir. The split in the warning list matches this exactly.

**This PR does not fix that**, and no image change can: it's an entrypoint/state-reconciliation problem. Removing `state/openclaw.sqlite` once lets the gateway reseed it from the image (back up the state dir first — that DB holds more than the plugin index). I did not make the entrypoint force-restore it, because overwriting shared state to clear a warn-level finding is a bad trade, and reconciling just the plugin rows means parsing an upstream SQLite schema that can change under us. Worth discussing as a follow-up.

## What this PR does do

**Drops `@openclaw/diffs`.** Its useful mode — rendering a diff to PNG/PDF for delivery over a chat channel — needs Chromium, which `-slim` strips along with Puppeteer. That leaves a gateway-hosted HTML viewer whose links default to loopback and need `security.allowRemoteViewer` plus a `viewerBaseUrl` to resolve anywhere useful. Not worth exposing tokenised viewer URLs through the ingress for a convenience plugin.

**Adds `assert-plugin-integrity.mjs` as a build gate.** Fails the build if any install record lacks an integrity hash — nothing backfills it, and a deployed gateway can't reinstall (read-only rootfs, no registry egress, `OPENCLAW_OFFLINE=1`), so build time is the only place it can be guaranteed. It also fails when it finds **no** records at all, since a shape change in `openclaw plugins inspect --all --json` would otherwise reduce the check to a no-op that always passes.

Its first green run is also the evidence for the claim above — that npm installs do record integrity.

**Alphabetical order** for install lines, the Dockerfile comment block, and the README table.

## On `xai`

It can't be dropped here — it's bundled in the base image under `/app/dist/extensions`, not installed by this Dockerfile. Removing it would mean deleting an upstream extension directory. It's already inert: not in `plugins.allow`, and `code_execution` is denied.

## Testing

- `pre-commit run` on all changed files: passing.
- `assert-plugin-integrity.mjs` unit-tested on three inputs: all-present (exit 0), one missing (exit 1, names it), shape-changed (exit 1, reports top-level keys).
- Image build is CI's job — no Docker locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)