### PR TITLE
chore(github-actions): update ppat/github-workflows (v4.2.0 -> v5.0.1)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   detect-changes:
-    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       # yamllint disable-line rule:indentation
       files_yaml: |
@@ -38,7 +38,7 @@ jobs:
 
   commit-messages:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref }}
       fetch_depth: ${{ github.event.pull_request.commits || 0 }}
@@ -48,7 +48,7 @@ jobs:
   docker-files:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).docker_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-hadolint.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-hadolint.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).docker_all_changed_files }}
@@ -57,7 +57,7 @@ jobs:
   github-actions:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).actions_all_changed_files }}
@@ -65,20 +65,20 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).markdown_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).markdown_all_changed_files }}
 
   pre-commit:
-    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).renovate_all_changed_files }}
@@ -86,7 +86,7 @@ jobs:
   shellcheck:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).shellscripts_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
@@ -94,7 +94,7 @@ jobs:
   yaml:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).yaml_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}

--- a/.github/workflows/load-metadata.yaml
+++ b/.github/workflows/load-metadata.yaml
@@ -41,8 +41,11 @@ jobs:
       shell: bash
       env:
         METADATA_FILE: "./${{ inputs.image_name }}/metadata.yaml"
+      # yamllint disable-line rule:indentation
       run: |
-        echo "image_version=$(yq .image_version $METADATA_FILE)" >> $GITHUB_OUTPUT
-        echo "label_title=$(yq .label_title $METADATA_FILE)" >> $GITHUB_OUTPUT
-        echo "label_description=$(yq .label_description $METADATA_FILE)" >> $GITHUB_OUTPUT
-        echo "build_timeout=$(yq .build_timeout $METADATA_FILE)" >> $GITHUB_OUTPUT
+        {
+          echo "image_version=$(yq .image_version "$METADATA_FILE")"
+          echo "label_title=$(yq .label_title "$METADATA_FILE")"
+          echo "label_description=$(yq .label_description "$METADATA_FILE")"
+          echo "build_timeout=$(yq .build_timeout "$METADATA_FILE")"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -56,24 +56,26 @@ jobs:
         echo "Setting release tag to $RELEASE_TAG"
         echo "Setting release ref to $RELEASE_REF"
         echo
-        echo "release_ref=${RELEASE_REF}" >> $GITHUB_OUTPUT
-        echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
-        echo "release_timestamp=${RELEASE_TIMESTAMP}" >> $GITHUB_OUTPUT
+        {
+          echo "release_ref=${RELEASE_REF}"
+          echo "release_tag=${RELEASE_TAG}"
+          echo "release_timestamp=${RELEASE_TIMESTAMP}"
+        } >> "$GITHUB_OUTPUT"
         echo
         echo "Fetching all previous releases..."
-        gh api repos/${GITHUB_REPOSITORY}/releases > /tmp/all_releases.json
+        gh api "repos/${GITHUB_REPOSITORY}/releases" > /tmp/all_releases.json
         cat /tmp/all_releases.json | jq -r '. | sort_by(.published_at) | reverse | .[].tag_name' | pr -t -o 4
         echo
         echo "Filtering down to releases for this image..."
-        cat /tmp/all_releases.json | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | startswith("'${IMAGE_NAME}'/")) | .tag_name' > /tmp/image_release_tags.list
+        cat /tmp/all_releases.json | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | startswith("'"${IMAGE_NAME}"'/")) | .tag_name' > /tmp/image_release_tags.list
         cat /tmp/image_release_tags.list | pr -t -o 4
         echo
         echo "Determining previous release for this image..."
         LAST_RELEASE="$(head -1 /tmp/image_release_tags.list)"
         if [[ ! -z "${LAST_RELEASE}" ]]; then
-          LAST_RELEASE_SHA=$(git rev-list -n 1 $LAST_RELEASE)
-          echo $LAST_RELEASE | pr -t -o 4
-          echo $LAST_RELEASE_SHA | pr -t -o 4
+          LAST_RELEASE_SHA=$(git rev-list -n 1 "$LAST_RELEASE")
+          echo "$LAST_RELEASE" | pr -t -o 4
+          echo "$LAST_RELEASE_SHA" | pr -t -o 4
           CHANGELOG_RANGE="${LAST_RELEASE_SHA}..main"
         else
           echo "No previous release for ${IMAGE_NAME}." | pr -t -o 4
@@ -81,7 +83,7 @@ jobs:
         fi
         echo
         echo "Determining release notes..."
-        git log --no-decorate --no-color --no-merges --pretty=format:"- %s" $CHANGELOG_RANGE -- "${IMAGE_NAME}/" > /tmp/release_notes.txt
+        git log --no-decorate --no-color --no-merges --pretty=format:"- %s" "$CHANGELOG_RANGE" -- "${IMAGE_NAME}/" > /tmp/release_notes.txt
         cat /tmp/release_notes.txt | pr -t -o 4
         echo
         if (( $(wc -m < /tmp/release_notes.txt) > 0 )); then
@@ -96,7 +98,7 @@ jobs:
 
   publish:
     needs: [load-image-metadata, create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   renovate:
-    uses: ppat/github-workflows/.github/workflows/renovate.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/renovate.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       dry_run: ${{ github.event_name == 'pull_request' }}
       git_ref: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -24,7 +24,7 @@ jobs:
 
   test-build-bitwarden-cli:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: bitwarden-cli
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -24,7 +24,7 @@ jobs:
 
   test-build-freeradius-server:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: freeradius-server
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -24,7 +24,7 @@ jobs:
 
   test-build-obsidian:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: obsidian
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -24,7 +24,7 @@ jobs:
 
   test-build-openclaw:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -24,7 +24,7 @@ jobs:
 
   test-build-tools:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: tools
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/update-aqua-checksum.yaml
+++ b/.github/workflows/update-aqua-checksum.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   update-aqua-checksums:
-    uses: ppat/github-workflows/.github/workflows/update-aqua-checksums.yaml@10103e49c72fbd6d3e06d7e29f51815b9b8644a6 # v4.2.0
+    uses: ppat/github-workflows/.github/workflows/update-aqua-checksums.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref_name }}
       aqua_dirs: |

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -7,3 +7,8 @@ ignored:
 - DL3018
 - DL4001
 - SC2155
+# hadolint v2.15.1 (pulled in by the ppat/github-workflows v5.0.1 bump) added this rule. It
+# flags `FROM --platform=$TARGETPLATFORM` as redundant, but every final stage in this repo sets
+# it explicitly to mirror the `--platform=$BUILDPLATFORM` builder stages -- see CLAUDE.md's
+# "Conventions specific to this repo". Functionally a no-op either way; keep it for the symmetry.
+- DL3065

--- a/bitwarden-cli/Dockerfile
+++ b/bitwarden-cli/Dockerfile
@@ -31,6 +31,8 @@ COPY --link --chown=root:root --chmod=755 entrypoint.sh /entrypoint.sh
 
 ENV BW_HOST=""
 ENV BW_USER=""
+# Empty placeholder documenting a runtime `-e BW_PASSWORD=...` override, not a baked-in secret.
+# hadolint ignore=DL3064
 ENV BW_PASSWORD=""
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Bumps `ppat/github-workflows` from `v4.2.0` to `v5.0.1` across all 17 call sites in this repo,
and fixes the two things that version bump breaks in CI: actionlint's newly-active shellcheck
integration, and a new hadolint rule pulled in along the way. This repo is the outlier of this
update batch — it was pinned at `v4.2.0`, not `v4.4.0` like its siblings — so this bump also
absorbs the intermediate `v4.2.0 → v4.4.0` changes.

`v5.0.1` = `667d20d10c8756b11feeab1ee691825ccea8f991`, verified by resolving the `v5.0.1` tag
directly in `ppat/github-workflows`.

## Refs bumped (17 call sites, 12 unique reusable workflows)

| File | Reusable workflow |
|---|---|
| `lint.yaml` | `detect-changed-files.yaml`, `lint-commit-messages.yaml`, `lint-hadolint.yaml`, `lint-github-actions.yaml`, `lint-markdown.yaml`, `lint-pre-commit.yaml`, `lint-renovate-config-check.yaml`, `lint-shellcheck.yaml`, `lint-yaml.yaml` |
| `release-workflow.yaml` | `build-docker-image.yaml` |
| `renovate.yaml` | `renovate.yaml` |
| `test-build-{bitwarden-cli,freeradius-server,obsidian,openclaw,tools}.yaml` (x5) | `build-docker-image.yaml` |
| `update-aqua-checksum.yaml` | `update-aqua-checksums.yaml` |

`lint-zizmor.yaml` is not called anywhere in this repo, so its four new optional inputs don't
apply here.

## Wider span (v4.2.0 → v4.4.0), diffed alongside the last hop

Diffed every called workflow's `on.workflow_call.inputs` at both `v4.2.0` and `v5.0.1` directly
(not just the last hop) — **no input was renamed, removed, or added as required** on any of the
12 reusable workflows this repo calls, so no call site needed a `with:`/`secrets:` change.

Notable in the `v4.2.0 → v4.4.0` half of the span (all internal to the reusable workflows, none
needed a caller-side change):

- `hadolint/hadolint` `v2.14.0 → v2.15.1` (internal `HADOLINT_VERSION` env var in
  `lint-hadolint.yaml`) — **this is what actually broke `lint-hadolint.yaml` here**, see below.
- `docker/login-action` `v4.5.1 → v4.6.0` and `ppat/homelab-ops-actions` `v2.1.0 → v2.2.0` —
  internal to `build-docker-image.yaml` / the `setup-repository-tools` action, transparent to
  callers.
- A run of `renovatebot/renovate` tool-version bumps for the config-validator/renovate-config-check
  job, transparent to callers (verified below).

The `v4.4.0 → v5.0.1` half is the actionlint/shellcheck change (below), plus internal-only changes
(scoped-down GitHub App token permissions in `renovate.yaml`/`update-aqua-checksums.yaml`, a
release-please refactor this repo doesn't use, zizmor input additions this repo doesn't call) and
one same-day upstream commit (`#612`, "define a coherent commit taxonomy") that only touches
`ppat/github-workflows`' own repo conventions — not applicable here per the standing instruction
not to adopt new commit taxonomies.

## What broke, and the fix for each

### 1. actionlint's shellcheck integration (previously inert)

`v5.0.1` fixes a bug where actionlint always appended `--norc`, silently discarding
`lint-github-actions.yaml`'s `--rcfile .shellcheckrc` — so this repo's `.shellcheckrc` never
actually filtered anything, and shellcheck has **never run against this repo's workflow `run:`
blocks until now**. Reproduced locally: actionlint v1.7.12 + shellcheck v0.11.0 (the versions
`v5.0.1` pins) over every workflow file, `-shellcheck shellcheck` (mirroring
`lint-github-actions.yaml`'s new invocation) — **19 findings, 2 files, both this repo's own
local reusable workflows** (not the ones sourced from `ppat/github-workflows`):

| File | Rule | Count | Fix |
|---|---|---|---|
| `load-metadata.yaml` | SC2086 | 8 | quote `$METADATA_FILE`, `$GITHUB_OUTPUT` |
| `load-metadata.yaml` | SC2129 | 1 | combine 4 appends into one `{ ...; } >> "$GITHUB_OUTPUT"` block |
| `release-workflow.yaml` | SC2086 | 9 | quote `$GITHUB_OUTPUT` x3, `$GITHUB_REPOSITORY`, `$IMAGE_NAME` (inside a jq filter), `$LAST_RELEASE`, `$LAST_RELEASE_SHA`, `$CHANGELOG_RANGE` |
| `release-workflow.yaml` | SC2129 | 1 | combine 3 appends into one `{ ...; } >> "$GITHUB_OUTPUT"` block |

All 19 fixed by quoting/restructuring, not by suppression — every variable involved holds a
single-token value with no whitespace or glob characters in practice (a fixed metadata file path,
a GitHub Actions default env var, a git tag/SHA/range, this repo's own image name), so quoting
cannot change what argv the command receives. Argv-equivalence proven with a stub harness (see
below) for the four less-obvious ones (`gh api`, the `jq` filter built by string concatenation,
`git rev-list`, `git log`) rather than asserted.

**Argv proofs** (stub functions record argv verbatim, before vs. after diffed byte-for-byte,
using representative real values — `IMAGE_NAME=bitwarden-cli`,
`GITHUB_REPOSITORY=ppat/images`, `LAST_RELEASE=bitwarden-cli/1.2.3-1700000000`,
`LAST_RELEASE_SHA=deadbeef`, `CHANGELOG_RANGE=deadbeef..main`):

```
=== gh argv diff (before vs after) ===
IDENTICAL
=== jq argv diff (before vs after) ===
IDENTICAL
=== git argv diff (before vs after) ===
IDENTICAL
```

No `# shellcheck disable=` was needed anywhere in this repo's own workflows — every finding here
was a real, safe quoting fix, not a case requiring the "prove it can't be quoted, suppress
instead" fallback.

### 2. hadolint v2.14.0 → v2.15.1 (pulled in by `lint-hadolint.yaml`'s own version bump)

Not shellcheck-related — a new hadolint version, surfaced by reproducing
`lint-hadolint.yaml`'s exact invocation (`hadolint --config=.hadolint.yaml --failure-threshold
warning <file>`) locally with both versions. **v2.14.0 (current pin) is clean on all 5
Dockerfiles; v2.15.1 (what `v5.0.1` pins) fails 4 of 5**:

| File | Rule | Decision |
|---|---|---|
| `bitwarden-cli`, `freeradius-server`, `obsidian`, `openclaw` Dockerfiles | DL3065 (`FROM --platform=$TARGETPLATFORM` called "redundant") | Ignored repo-wide in `.hadolint.yaml`. This repo's `CLAUDE.md` documents `--platform=$BUILDPLATFORM` builder / `--platform=$TARGETPLATFORM` final-stage as a deliberate, repo-wide convention for cross-compilation clarity. Hadolint is technically correct that it's a runtime no-op, but removing it would break that documented symmetry for no behavioural gain — same trade-off as the existing `DL3008`/`DL3018`/`DL4001`/`SC2155` repo-wide ignores. |
| `bitwarden-cli/Dockerfile` | DL3064 (sensitive data in `ENV BW_PASSWORD=""`) | Inline `# hadolint ignore=DL3064` on that one line. It's an empty placeholder documenting the `-e BW_PASSWORD=...` runtime override, not a baked-in secret — a real false positive on this specific line, not a pattern to suppress repo-wide. |
| `obsidian/Dockerfile` | DL3066 (non-numeric `USER obsidian`), info severity | Left alone — below the `--failure-threshold=warning` gate, doesn't fail the job, and using a named user is the intended convention here. |

Reproduced clean after the fix: `hadolint --config=.hadolint.yaml --failure-threshold warning`
exits 0 on all 5 Dockerfiles (only the harmless DL3066 info line still prints for `obsidian`).

## `obsidian/auto-trust.py` / SC1071

Confirmed **this repo's `main` branch is currently red** on `lint.yaml`'s `shellcheck` job for
every scheduled (ALL-scope) run since 2026-08-03 — `obsidian/auto-trust.py` is executable with a
`#!/usr/bin/env python3` shebang, and the old `-executable`-only file selector fed it straight to
shellcheck, which fails outright with SC1071 (unsupported dialect). Verified this by literally
reproducing the old selector locally (`find ... -executable`) and the new shebang/extension-based
one from `v5.0.1`:

- **Before** (old `-executable` selector): 4 files — `bitwarden-cli/entrypoint.sh`,
  `obsidian/auto-trust.py`, `obsidian/docker-entrypoint.sh`, `openclaw/docker-entrypoint.sh`.
  Fails: SC1071 on `auto-trust.py`.
- **After** (new shebang/extension selector): 3 files — `auto-trust.py` correctly drops out (no
  shell shebang, `.py` extension). All 3 remaining files pass, 0 failed.

**SC1071 is resolved by this bump** — no coverage regression, the one file that disappeared is
exactly the one the task flagged as expected, and nothing else dropped out.

## Superseded PRs

#558 (`v4.2.0 → v4.4.0`) and #560 (`v4.2.0 → v5.0.0`) are both superseded by this PR. Left
untouched — not closed, not modified, per standing instructions.

## Out of scope, left alone

- `commitlint.config.js` / `scope-enum` and the `renovate-presets` pin — untouched, per standing
  instructions (this is purely the `github-workflows` bump).
- #526 (`actions/checkout` `v4.4.0 → v7.0.1`) — a different dependency, out of scope, not folded
  in. Worth noting for awareness: this repo's own top-level workflows
  (`load-metadata.yaml`, `release-workflow.yaml`) still pin `actions/checkout@...# v4` directly
  (unrelated to the `ppat/github-workflows` refs this PR bumps), so it's still on checkout v4
  independent of whether #526 lands.
- A pre-existing, unrelated markdownlint table-formatting drift in `tools/README.md` (present on
  `main`, `pre-commit run --all-files` auto-fixes it locally) — not touched; out of scope for this
  bump and not something `v5.0.1` causes.

## CI status

Watching CI on this PR now; will report per-job results (and dispatch `lint.yaml` directly on
this branch for full ALL-scope coverage if any job is path-gated out of the PR's changed-file
set) before asking for review.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
