### PR TITLE
feat(github-actions): migrate to build-docker-image v6.0.0 and publish to ghcr.io on release builds

### DIFF
--- a/.github/workflows/publish-bitwarden-cli.yaml
+++ b/.github/workflows/publish-bitwarden-cli.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-freeradius-server.yaml
+++ b/.github/workflows/publish-freeradius-server.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-obsidian.yaml
+++ b/.github/workflows/publish-obsidian.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-openclaw.yaml
+++ b/.github/workflows/publish-openclaw.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-tools.yaml
+++ b/.github/workflows/publish-tools.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -98,7 +98,7 @@ jobs:
 
   publish:
     needs: [load-image-metadata, create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -98,7 +98,7 @@ jobs:
 
   publish:
     needs: [load-image-metadata, create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -98,7 +98,7 @@ jobs:
 
   publish:
     needs: [load-image-metadata, create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}
@@ -107,7 +107,7 @@ jobs:
       platforms: ${{ inputs.platforms }}
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/${{ inputs.image_name }}
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/${{ inputs.image_name }}
-      source_git_ref: ${{ needs.create-release.outputs.release_ref }}
+      git_ref: ${{ needs.create-release.outputs.release_ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -102,6 +102,7 @@ jobs:
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}
+      ghcr_repository: ppat/${{ inputs.image_name }}
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
       label_description: ${{ needs.load-image-metadata.outputs.label_description }}
       platforms: ${{ inputs.platforms }}

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-bitwarden-cli:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: bitwarden-cli
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/bitwarden-cli
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/bitwarden-cli
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-bitwarden-cli:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: bitwarden-cli
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-bitwarden-cli:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: bitwarden-cli
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-freeradius-server:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: freeradius-server
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-freeradius-server:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: freeradius-server
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/freeradius-server
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/freeradius-server
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-freeradius-server:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: freeradius-server
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-obsidian:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: obsidian
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-obsidian:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: obsidian
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/obsidian
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/obsidian
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-obsidian:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: obsidian
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-openclaw:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-openclaw:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-openclaw:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -37,7 +38,7 @@ jobs:
       platforms: linux/amd64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/openclaw
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/openclaw
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-tools:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
     with:
       image_context_path: tools
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-tools:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: tools
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/tools
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/tools
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test-build-tools:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@59629d576a6f1f02a5794257e7a6bea4f31f9992 # v6.0.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@5a96ced8ceefd58062f6b91ee9d6f3a31cd06e1c # v6.0.0
     with:
       image_context_path: tools
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}


### PR DESCRIPTION
## Summary

Migrates all 6 `build-docker-image.yaml` call sites (`release-workflow.yaml` plus the 5
`test-build-<image>.yaml` PR-build workflows) to `ppat/github-workflows`'s upcoming v6, and
enables `ghcr.io` as a fourth publish target for release builds only.

Two commits:

1. **`chore(github-actions)`** -- the mechanical v6 migration: pin bump, `source_git_ref` ->
   `git_ref` rename, and the `packages: write` permissions grant v6 requires.
2. **`feat(release)`** -- the new capability: routes release builds to `ghcr.io/ppat/<image>` via
   the new `ghcr_repository` input.

## v6 breaking changes and what changed at each call site

`ppat/github-workflows` PR [#615](https://github.com/ppat/github-workflows/pull/615) (not yet
merged) makes three consumer-visible changes to `build-docker-image.yaml`:

- **BREAKING:** input `source_git_ref` renamed to `git_ref`.
- **BREAKING:** output `image_id` removed. Verified with `git grep -n image_id` -- nothing in this
  repo reads it, so no call site needed a compensating change beyond the input rename.
- New optional input `ghcr_repository` (`org/name`, host implicit, must be lowercase). No new
  secrets -- auth uses the ambient `GITHUB_TOKEN`.

| File | Change |
|---|---|
| `release-workflow.yaml` (`publish` job) | `source_git_ref:` -> `git_ref:`; pin bump; new `ghcr_repository: ppat/${{ inputs.image_name }}` (mirrors the existing `dockerhub_repository: ppatlabs/${{ inputs.image_name }}`) |
| `test-build-{bitwarden-cli,freeradius-server,obsidian,openclaw,tools}.yaml` (x5) | `source_git_ref:` -> `git_ref:`; pin bump. **No** `ghcr_repository` added -- PR builds deliberately don't publish, mirroring the existing `dockerhub_repository` omission in these files |

## Why every call site needs `packages: write`, even non-GHCR ones

v6's `build-image` job now declares `permissions: {contents: read, packages: write}`
**unconditionally** in its own `permissions:` block -- GitHub Actions accepts no expressions
there, so the job can't request `packages: write` only when it's actually about to push to GHCR.

Proven by experiment against the PR #615 branch: a caller that doesn't also grant `packages:
write` at the job/workflow level fails to *load* entirely -- zero jobs run, no annotations appear,
just:

```
The nested job 'build-image' is requesting 'packages: write', but is only allowed 'packages: none'
```

This hits **every** caller, GHCR or not. So `packages: write` is added to:

- All 5 `test-build-<image>.yaml` workflows, alongside their existing `contents: read`.
- All 5 `publish-<image>.yaml` workflows, alongside their existing `contents: write` -- which is
  **restated**, not replaced, since specifying any `permissions:` block zeroes every unlisted
  scope, and `release-workflow.yaml`'s `create-release` job does `gh release create` with
  `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, inheriting `contents: write` from exactly this block.
  Dropping it would silently break every release.

## GHCR is release-path-only, deliberately

Same pattern as `dockerhub_repository` today: only `release-workflow.yaml`'s call to
`build-docker-image.yaml` passes `ghcr_repository`. The 5 `test-build-<image>.yaml` PR-build
workflows do not, so PR builds never push to GHCR (or Docker Hub) -- publishing is gated purely by
which call sites pass the repository input, no separate flag needed.

## The pin points at an unmerged PR branch

`a6829b4b819f7c39adabf277c7d87a1e663c186d` is `ppat/github-workflows` PR #615's **head SHA**, not
a tag. That PR is still open and no `v6*` tag exists yet. **This must be repointed to the real
`v6.0.0` tag before this PR merges** -- do not merge as-is.

## What this proves, and what it doesn't

A green CI run on this PR proves the v6 migration loads and PR builds still work end-to-end. It
does **not** exercise the release path: `publish-<image>.yaml` (and therefore
`release-workflow.yaml`'s `publish` job, the GHCR push, and the restated `contents: write` for
`gh release create`) only fires on push to `main`. That path stays unverified until this merges
and a real release runs.

## Test plan

- [x] `pre-commit run --all-files` passes (commitlint verified manually against
      `commitlint.config.js`'s rules -- the pre-commit cache's local commitlint tool has a broken
      node_env in this environment, unrelated to this change)
- [x] All 5 `test-build-*` CI runs load and start (no `startup_failure`) -- the direct test that
      the `packages: write` grant is correctly placed
- [ ] Release path (`publish-*.yaml` -> GHCR push -> `gh release create`) -- unexercised until
      merge, see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)