### PR TITLE
test: A/B measurement - obsidian build cache OFF (do not merge)

### DIFF
--- a/.github/workflows/publish-bitwarden-cli.yaml
+++ b/.github/workflows/publish-bitwarden-cli.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-freeradius-server.yaml
+++ b/.github/workflows/publish-freeradius-server.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-obsidian.yaml
+++ b/.github/workflows/publish-obsidian.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-openclaw.yaml
+++ b/.github/workflows/publish-openclaw.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-tools.yaml
+++ b/.github/workflows/publish-tools.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -98,7 +98,7 @@ jobs:
 
   publish:
     needs: [load-image-metadata, create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}
@@ -107,7 +107,7 @@ jobs:
       platforms: ${{ inputs.platforms }}
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/${{ inputs.image_name }}
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/${{ inputs.image_name }}
-      source_git_ref: ${{ needs.create-release.outputs.release_ref }}
+      git_ref: ${{ needs.create-release.outputs.release_ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -102,6 +102,7 @@ jobs:
     with:
       image_context_path: ${{ inputs.image_name }}
       dockerhub_repository: ppatlabs/${{ inputs.image_name }}
+      ghcr_repository: ppat/${{ inputs.image_name }}
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
       label_description: ${{ needs.load-image-metadata.outputs.label_description }}
       platforms: ${{ inputs.platforms }}

--- a/.github/workflows/test-build-bitwarden-cli.yaml
+++ b/.github/workflows/test-build-bitwarden-cli.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-bitwarden-cli:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: bitwarden-cli
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/bitwarden-cli
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/bitwarden-cli
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-freeradius-server.yaml
+++ b/.github/workflows/test-build-freeradius-server.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-freeradius-server:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: freeradius-server
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/freeradius-server
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/freeradius-server
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -32,7 +32,6 @@ jobs:
       label_description: ${{ needs.load-image-metadata.outputs.label_description }}
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/obsidian
-      private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/obsidian
       git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:

--- a/.github/workflows/test-build-obsidian.yaml
+++ b/.github/workflows/test-build-obsidian.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-obsidian:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: obsidian
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/obsidian
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/obsidian
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-openclaw.yaml
+++ b/.github/workflows/test-build-openclaw.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-openclaw:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: openclaw
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -37,7 +38,7 @@ jobs:
       platforms: linux/amd64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/openclaw
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/openclaw
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/test-build-tools.yaml
+++ b/.github/workflows/test-build-tools.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   load-image-metadata:
@@ -24,7 +25,7 @@ jobs:
 
   test-build-tools:
     needs: [load-image-metadata]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@a6829b4b819f7c39adabf277c7d87a1e663c186d # v6.0.0
     with:
       image_context_path: tools
       label_title: ${{ needs.load-image-metadata.outputs.label_title }}
@@ -32,7 +33,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       private_registry_repository: ${{ vars.CONTAINER_REGISTRY_PATH }}/tools
       private_registry_build_cache: ${{ vars.CONTAINER_REGISTRY_CACHE_PATH }}/tools
-      source_git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
+      git_ref: ${{ (github.event_name == 'pull_request') && format('refs/heads/{0}', github.head_ref) || github.ref }}
       timeout_minutes: ${{ fromJSON(needs.load-image-metadata.outputs.build_timeout) }}
     secrets:
       private_registry_username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}


### PR DESCRIPTION
Temporary measurement PR for a controlled A/B test of registry-backed build caching over the Tailscale/Harbor path. Removes only the `private_registry_build_cache` line from `test-build-obsidian.yaml` to measure cache-OFF wall clock vs the cache-ON baseline on `feat/ghcr-and-v6-migration`. Do not merge — will be closed after measurement.